### PR TITLE
Fix issue with _.isObject test before _.isFunction

### DIFF
--- a/backbone.layoutmanager.js
+++ b/backbone.layoutmanager.js
@@ -210,14 +210,15 @@ var LayoutManager = Backbone.LayoutManager = Backbone.View.extend({
       // Ensure the cache is up-to-date
       LayoutManager.cache(url, contents);
 
-      // Context is an object
-      if (_.isObject(options.serialize)) {
-        context = options.serialize;
-
       // Context is a function
-      } else if (_.isFunction(options.serialize)) {
+      if (_.isFunction(options.serialize)) {
         context = options.serialize.call(manager);
+
+      // Context is an object
+      } else if (_.isObject(options.serialize)) {
+        context = options.serialize;
       }
+
 
       // Set the layout
       manager.el.innerHTML = options.render.call(options, contents, context);

--- a/test/views.js
+++ b/test/views.js
@@ -105,3 +105,35 @@ asyncTest("nested views", function() {
     start();
   });
 });
+
+test('serialize on LayoutManager is a function', function() {
+  var testText = 'test text',
+
+  main = new Backbone.LayoutManager({
+    template: '#test-sub',
+    serialize: function() {
+      return {
+        text: 'test text',
+      };
+    }
+  });
+
+  main.render(function(contents) {
+    equal($.trim($(contents).text()), testText, 'correct serialize');
+  });
+});
+
+test('serialize on LayoutManager is an object', function() {
+  var testText = 'test text',
+
+  main = new Backbone.LayoutManager({
+    template: '#test-sub',
+    serialize: {
+      text: 'test text',
+    }
+  });
+
+  main.render(function(contents) {
+    equal($.trim($(contents).text()), testText, 'correct serialize');
+  });
+});


### PR DESCRIPTION
If a serialize function is defined in the options object of a LayoutManager, the test for _.isObject(function) happens first, which passes, when in actuality the return value for the function is what is wanted, not the function itself.

Doing the _.isFunction test before the _.isObject test fixes this.

Added two test cases which illustrate the fix.
