### PR TITLE
Return the view that was instantiated by #view

### DIFF
--- a/backbone.layoutmanager.js
+++ b/backbone.layoutmanager.js
@@ -179,7 +179,7 @@ var LayoutManager = Backbone.LayoutManager = Backbone.View.extend({
     
     view.render = wrappedRender(manager, name, view);
     
-    this.views[name] = view;
+    return this.views[name] = view;
   },
 
   render: function(done) {

--- a/test/views.js
+++ b/test/views.js
@@ -75,8 +75,7 @@ asyncTest("re-render a view defined after initialization", function(){
   trimmed = $.trim( $("#container .inner-left").html() );
   equal(trimmed, "Right", "Correct re-render");
   
-  main.view(".right", new this.View({ msg: "Right Again" }));
-  main.views[".right"].render();
+  main.view(".right", new this.View({ msg: "Right Again" })).render();
   trimmed = $.trim( $("#container .inner-left").html() );
   equal(trimmed, "Right Again", "Correct re-render");
 })


### PR DESCRIPTION
When you instantiate a view through #view the view that was instantiated is returned allowing for chaining.

```
main.view(".header", new HeaderView).render();
```
