### PR TITLE
Makes the default underscore configuration a little more foolproof 

### DIFF
--- a/backbone.layoutmanager.js
+++ b/backbone.layoutmanager.js
@@ -398,7 +398,7 @@ LayoutManager.prototype.options = {
 
   // By default, render using underscore's templating.
   render: function(template, context) {
-    return template(context);
+    return template.call(context, context);
   }
 
 };


### PR DESCRIPTION
In a toy application I'm writing, the compiled _.template function was being invoked at this point with DOMWindow as the context, which meant that:

``` javascript
<% alert(this) %>
```

Was alerting DOMWindow, and the context object wasn't accessible.
