### PR TITLE
allow appending of views

### DIFF
--- a/backbone.layoutmanager.js
+++ b/backbone.layoutmanager.js
@@ -201,7 +201,7 @@ var LayoutManager = Backbone.View.extend({
 
     // Make sure any existing views are completely scrubbed of
     // events/properties.  Do not run clean on append items.
-    if (this.views[name]) {
+    if (this.views[name] && !append) {
       cleanViews(this.views[name]);
     }
 
@@ -235,9 +235,7 @@ var LayoutManager = Backbone.View.extend({
         });
       }
 
-      if (!append) {
-        view.__manager__.isManaged = true;
-      }
+      view.__manager__.isManaged = true;
 
       view.render = function(done) {
         var viewDeferred = options.deferred();


### PR DESCRIPTION
I think appending of views does not work correctly.
I want to append a new view without re-rendering all other views.

I have a list view and an item view, just like the documentation describes.
I want to insert a new item view, when the collection has a new item.

i am doing:
    @collection.bind("add", (item) =>
      nv = new ItemView(
              model: item
      )
      v = this.view("#notes", nv, true)
      v.render()
    )

but this removes every view instead.
therefore i think calling cleanViews with append = true is false.

or how are you supposed to insert a new view without re-rendering?
