### PR TITLE
Fix bug in HTML rendering in Node.js

### DIFF
--- a/node/index.js
+++ b/node/index.js
@@ -99,13 +99,13 @@ var $ = require("cheerio");
     // element to replace the innerHTML with.
     html: function(root, el) {
       var $root = root[0] ? root : $(root);
-      $root.html(_.isString(el) ? el : $(el).html());
+      $root.html(_.isString(el) ? el : $.render(el));
     },
 
     // Very similar to HTML except this one will appendChild.
     append: function(root, el) {
       var $root = root[0] ? root : $(root);
-      $root.append(_.isString(el) ? el : $(el).html());
+      $root.append(_.isString(el) ? el : $.render(el));
     },
 
     when: function(promises) {


### PR DESCRIPTION
When supplied with a Cheerio instance (instead of a string of HTML), the
Node.js-specific `html` and `append` methods should reference the
complete outer HTML (not just the contents) as generated by Cheerio's
`render` method.

Since there's no Node.js test harness, I can't add a regression test for
this. If necessary, I can put together something simple with NodeUnit, but
I thought I'd check here first.

This resolves issue #162.
