### PR TITLE
parentViews within _removeView is returning undefined elements

### DIFF
--- a/backbone.layoutmanager.js
+++ b/backbone.layoutmanager.js
@@ -485,7 +485,7 @@ var LayoutManager = Backbone.View.extend({
         // Remove directly from the Array reference.
         return _.each(parentViews, function(view, i) {
           // If the managers match, splice off this View.
-          if (view.__manager__ === manager) {
+          if (view != null && view.__manager__ === manager) {
             aSplice.call(parentViews, i, 1);
           }
         });


### PR DESCRIPTION
Not sure what could be causing `parentViews` to be returning an array with `undefined` elements. Here is a temporary fix. This occurs when trying to removing old views when doing a `insertView()`.

I **suspect** it might be something to do with `aSplice`. I didn't have this problem with 3bd09bb06495738d93fd5ceded64488ba7b10355
