### PR TITLE
insertViews should be able to accept an array of views

### DIFF
--- a/backbone.layoutmanager.js
+++ b/backbone.layoutmanager.js
@@ -57,6 +57,12 @@ var LayoutManager = Backbone.View.extend({
   // Iterate over an object and ensure every value is wrapped in an array to
   // ensure they will be appended, then pass that object to `setViews`.
   insertViews: function(views) {
+    // If an array of views was passed it should be inserted into the
+    // root view. Much like calling insertView without a selector
+    if (_.isArray(views)) {
+      return this.setViews({'': views});
+    }
+
     _.each(views, function(view, selector) {
       views[selector] = _.isArray(view) ? view : [view];
     });

--- a/test/views.js
+++ b/test/views.js
@@ -1674,3 +1674,29 @@ test("getView should accept a selector name too", 3, function() {
   equal(view.getViews("b").value()[0], b, "Using getViews will return the single view in an array");
   equal(view.getViews("c").value().length, 2, "Two Views returned from getViews");
 });
+
+asyncTest("insertViews should accept a single array", 1, function() {
+  var main = new Backbone.Layout({
+    template: "#main"
+  });
+
+  var listElems = [new Backbone.LayoutView({tagName: "li"}),
+                   new Backbone.LayoutView({tagName: "li"})];
+
+  var list = new Backbone.LayoutView({
+    tagName: "ul",
+
+    beforeRender: function() {
+      this.insertViews(listElems);
+    }
+  });
+
+  main.setView('.right', list);
+
+  main.render().done(function() {
+    var items = this.$(".right ul li");
+
+    equal(items.length, 2, "Proper array insert");
+    start();
+  });
+});


### PR DESCRIPTION
`InsertViews` can now accept an array of view elements and will append them to the root of the view. Much like how calling `insertView` without a selector appends to the root of the view.

This is to fix the following inconsistency:

```
var views = [new Backbone.LayoutView(), new Backbone.LayoutView()]; 

_.each(views, function(view) { this.insertView(view); } // inserts each view to the root of {this}

this.insertViews(views); // currently throws an exception
```
