### PR TITLE
Fix bug in removing duplicate sub-views

### DIFF
--- a/backbone.layoutmanager.js
+++ b/backbone.layoutmanager.js
@@ -217,11 +217,11 @@ var LayoutManager = Backbone.View.extend({
       // Ensure events are always correctly bound after rendering.
       root.delegateEvents();
 
-      // Resolve the deferred.
-      def.resolveWith(root, [root]);
-
       // Set this View as successfully rendered.
       manager.hasRendered = true;
+
+      // Resolve the deferred.
+      def.resolveWith(root, [root]);
 
       // Only process the queue if it exists.
       if (next = manager.queue.shift()) {

--- a/test/views.js
+++ b/test/views.js
@@ -1745,3 +1745,29 @@ test("cleanup hit", 1, function() {
 
   equal(collection._callbacks.reset, undefined, "Reset event does not exist");
 });
+
+asyncTest("Duplicate sub-views are removed when their parent view is rendered repeatedly", 1, function() {
+  var ListItemView = Backbone.LayoutView.extend({
+    // Set a template source so LayoutManager calls this view's `fetch` method
+    // (the actual value is unimportant for this test)
+    template: "#bogus",
+    // Generic asynchronous `fetch` method
+    fetch: function(name) {
+      var done = this.async();
+      setTimeout(function() {
+        done(_.template(""));
+      }, 0);
+    }
+  });
+
+  var list = new Backbone.LayoutView({
+    beforeRender: function() {
+      this.insertView(new ListItemView());
+    }
+  });
+
+  $.when(list.render(), list.render()).done(function() {
+    equal(list.views[""].length, 1, "All repeated sub-views have been removed");
+    start();
+  });
+});


### PR DESCRIPTION
Conditions that triggered this bug:
- A view has a sub-view which renders asynchronously due to an
  asynchronous `fetch` method
- The view's `render` method is invoked multiple times before the
  sub-view's `fetch` method resolves

Result:

The sub-view created in the first call to `render` is not removed by the
second call, yeilding repeated sub-views.

Fix:

Set the view's `hasRendered` flag _before_ resolving the `render` method's
deferred.
