### PR TITLE
Node package "underscore" dependency

### DIFF
--- a/node/index.js
+++ b/node/index.js
@@ -2,7 +2,7 @@ var fs = require("fs");
 var util = require("util");
 
 var Backbone = require("backbone");
-var _ = require("backbone/node_modules/underscore");
+var _ = require("underscore");
 var def = require("underscore.deferred");
 var $ = require("cheerio");
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "dependencies": {
     "backbone": "0.9.2",
     "underscore.deferred": "0.2.0",
-    "cheerio": "0.10.1"
+    "cheerio": "0.10.1",
+    "underscore": "1.4.2"
   },
 
   "devDependencies": {


### PR DESCRIPTION
https://github.com/tbranyen/backbone.layoutmanager/blob/3fb562160e337cdb081f337e9e1e89fd453bdfc5/node/index.js#L5 has been causing me a bit of trouble.

It looks like NPM doesn't install sub-dependencies into things like Backbone if they're already satisfied by the dependency chain somewhere else.

This means if I require underscore myself, or have another package that is resolved before layout manager, that require line doesn't work since there is no backbone/node_modules/underscore.

Is there a reason that underscore (or lodash) isn't specified as a dependency?
