### PR TITLE
Rename 'append' to 'insert'

### DIFF
--- a/backbone.layoutmanager.js
+++ b/backbone.layoutmanager.js
@@ -764,8 +764,18 @@ LayoutManager.prototype.options = {
     // If no selector is specified, assume the parent should be added to.
     var $root = name ? $(root).find(name) : $(root);
 
-    // Use the insert method if insert argument is true.
-    this[insert ? "insert" : "html"]($root, el);
+    // Use the insert method if insert argument is true
+    if (insert) {
+      // Maintain backwards compatability with v0.7.2 by first checking if a
+      // custom `append` method has been specified.
+      if (this.append !== LayoutManager.prototype.options.append) {
+        this.append($root, el);
+      } else {
+        this.insert($root, el);
+      }
+    } else {
+      this.html($root, el);
+    }
   },
 
   // Override this with a custom HTML method, passed a root element and an
@@ -794,6 +804,10 @@ LayoutManager.prototype.options = {
     return $.contains(parent, child);
   }
 };
+
+// Maintain backwards compatability with v0.7.2
+LayoutManager.prototype.options.append =
+  LayoutManager.prototype.options.insert;
 
 // Maintain a list of the keys at define time.
 keys = _.keys(LayoutManager.prototype.options);

--- a/test/configure.js
+++ b/test/configure.js
@@ -29,7 +29,7 @@ module("configure", {
 });
 
 // Ensure the correct defaults are set for all Layout and View options.
-test("defaults", 16, function() {
+test("defaults", 18, function() {
   // Create a new Layout to test.
   var layout = new this.Layout();
   // Create a new Layout to test.
@@ -47,6 +47,8 @@ test("defaults", 16, function() {
   ok(_.isFunction(layout.options.html), "Layout: html is a function");
   // The insert property should be a function.
   ok(_.isFunction(layout.options.insert), "Layout: insert is a function");
+  // The append property should be a function.
+  ok(_.isFunction(layout.options.insert), "Layout: append is a function");
   // The when property should be a function.
   ok(_.isFunction(layout.options.when), "Layout: when is a function");
   // The render property should be a function.
@@ -63,6 +65,8 @@ test("defaults", 16, function() {
   ok(_.isFunction(view.options.html), "View: html is a function");
   // The insert property should be a function.
   ok(_.isFunction(view.options.insert), "View: insert is a function");
+  // The append property should be a function.
+  ok(_.isFunction(view.options.insert), "View: append is a function");
   // The when property should be a function.
   ok(_.isFunction(view.options.when), "View: when is a function");
   // The render property should be a function.

--- a/test/views.js
+++ b/test/views.js
@@ -1814,6 +1814,29 @@ test("'insertView' uses user-defined `insert` method", 2, function() {
   equal(layout.$el.text(), "HelloWorld", "Used user-defined `insert` method to insert view HTML into layout");
 });
 
+test("'insertView' falls back on user-defined `append` method if custom `insert` method is not found", function() {
+
+  var hit = false;
+  var layout = new Backbone.Layout({
+    template: _.template("<div class='test'>World</div>"),
+    fetch: _.identity
+  });
+
+  layout.insertView(".test", new Backbone.Layout({
+      template: _.template("Hello"),
+      fetch: _.identity,
+      append: function($root, child) {
+        $root.before(child);
+        hit = true;
+      }
+    }));
+
+  layout.render();
+
+  ok(hit, "Invoked user-defined `append` method when rendering");
+  equal(layout.$el.text(), "HelloWorld", "Used user-defined `append` method to insert view HTML into layout");
+});
+
 // https://github.com/tbranyen/backbone.layoutmanager/issues/222
 test("Different Orders of Rendering for a Re-Render", 2, function() {
   var msg = "";


### PR DESCRIPTION
Submitting for consideration in v0.8 (#212).

The name `insert` is more generic: it does not imply the method by which
elements are added to the DOM. Since this method is intended to be
overridden with any arbitray insertion logic, the API should not suggest
what form that method takes.

For example, the following sample from the project documentation defines an `append` method that prepends content into the DOM. This feels a little awkward:

``` javascript
var ListView = Backbone.View.extend({
  beforeRender: function() {
    // Append a new ItemView into the nested <UL>.
    this.insertView("ul", new ItemView({
      // Prepend the element instead of append.
      append: function(root, child) {
        $(root).prepend(child);
      }
    }));
  }
});
```

I think the API I'm proposing is a little more logical:

``` javascript
var ListView = Backbone.View.extend({
  beforeRender: function() {
    // Append a new ItemView into the nested <UL>.
    this.insertView("ul", new ItemView({
      // Prepend the element instead of append.
      insert: function(root, child) {
        $(root).prepend(child);
      }
    }));
  }
});
```

This can be made backward-compatable with 0.7.2, but the code's a little ugly. I've included the necessary logic in a separate commit in case you're in to that sort of thing.​​
