### PR TITLE
Simplify insertion methods

### DIFF
--- a/backbone.layoutmanager.js
+++ b/backbone.layoutmanager.js
@@ -384,7 +384,7 @@ var LayoutManager = Backbone.View.extend({
     function applyTemplate(rendered) {
       // Actually put the rendered contents into the element.
       if (rendered) {
-        options.html(root.el, rendered);
+        options.html(root.$el, rendered);
       }
 
       // Resolve only after fetch and render have succeeded.
@@ -753,13 +753,13 @@ LayoutManager.prototype.options = {
 
   // Override this with a custom HTML method, passed a root element and an
   // element to replace the innerHTML with.
-  html: function(root, el) {
-    $(root).html(el);
+  html: function($root, el) {
+    $root.html(el);
   },
 
   // Very similar to HTML except this one will appendChild.
-  append: function(root, el) {
-    $(root).append(el);
+  append: function($root, el) {
+    $root.append(el);
   },
 
   // Return a deferred for when all promises resolve/reject.

--- a/node/index.js
+++ b/node/index.js
@@ -100,14 +100,12 @@ var $ = require("cheerio");
 
     // Override this with a custom HTML method, passed a root element and an
     // element to replace the innerHTML with.
-    html: function(root, el) {
-      var $root = root[0] ? root : $(root);
+    html: function($root, el) {
       $root.html(_.isString(el) ? el : $(el).html());
     },
 
     // Very similar to HTML except this one will appendChild.
-    append: function(root, el) {
-      var $root = root[0] ? root : $(root);
+    append: function($root, el) {
       $root.append(_.isString(el) ? el : $(el).html());
     },
 


### PR DESCRIPTION
Update the internal "applyTemplate" function to use the jQuery-wrapped
version of the given view's element. This obviates the need to wrap the
object passed to "html" and "append", making the code:
1. More efficient (the jQuery elements created in "partial" are no longer
   needlessly re-wrapped)
2. More usable (user-specified "html" and "append" methods can rely on
   the root element being a full jQuery object, with all the benefits
   that brings)
