### PR TITLE
Preserve view ordering with varying render delays

### DIFF
--- a/backbone.layoutmanager.js
+++ b/backbone.layoutmanager.js
@@ -339,16 +339,15 @@ var LayoutManager = Backbone.View.extend({
           // If items are being inserted, they will be in a non-zero length
           // Array.
           if (insert && view.length) {
-            // Only need to wait for the first View to complete, the rest
-            // will be synchronous, by virtue of having the template cached.
-            return view[0].render().pipe(function() {
-              // Map over all the View's to be inserted and call render on
-              // them all.  Once they have all resolved, resolve the other
-              // deferred.
-              return options.when(_.map(view.slice(1), function(insertView) {
-                return insertView.render();
-              }));
-            });
+            // Schedule each view to be rendered in order and return a promise
+            // representing the result of the final rendering.
+            return _.reduce(view.slice(1), function(prevRender, view) {
+              return prevRender.then(function() {
+                return view.render();
+              });
+            // The first view should be rendered immediately, and the resulting
+            // promise used to initialize the reduction.
+            }, view[0].render());
           }
 
           // Only return the fetch deferred, resolve the main deferred after

--- a/test/views.js
+++ b/test/views.js
@@ -1676,3 +1676,35 @@ test("additional testing that view's without a parent can manage", 1, function()
 
   equal(layout.$el.filter(".right").children(".view0").length, 2, "Correct length");
 });
+
+asyncTest("Ordering sub-views with varying render delays", 1, function() {
+  var Outside = Backbone.View.extend({
+    manage: true,
+    template: "[outside]",
+    fetch: _.template
+  });
+  var Inside = Backbone.View.extend({
+    manage: true,
+    template: "[inside]",
+    fetch: function(str) {
+      var done = this.async();
+      setTimeout(function() {
+        done(_.template(str));
+      }, 0);
+    }
+  });
+  var Sandwich = Backbone.View.extend({
+    manage: true,
+    beforeRender: function() {
+      this.insertView(new Outside());
+      this.insertView(new Inside());
+      this.insertView(new Outside());
+    }
+  });
+
+  var sw = new Sandwich();
+  sw.render().done(function() {
+    equal(sw.$el.text(), "[outside][inside][outside]", "sub-view fetch delays do not affect ordering");
+    start();
+  });
+});


### PR DESCRIPTION
The one thing I don't like about this approach is that sub-views are being rendered in series. Ideally, we should render them (asynchronously) in parallel and then insert them (synchronously) in series. I'm still getting familiar with the source, so this may be a non-trivial change. What do you think, @tbranyen?

(commit message follows)

Because sub-views may have independant rendering delays, the parent view
must wait for each view to complete rendering before inserting the next.

This addresses the issue first identified by @peterjmit in issue #261.
