### PR TITLE
Update jamjs exports config

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
         "backbone",
         "underscore"
       ],
-      "exports": "Backbone.LayoutManager"
+      "exports": "Backbone.Layout"
     }
   }
 }


### PR DESCRIPTION
As `LayoutManager` is deprecated in favour of `Backbone.Layout`, the jamjs config should be updated too.

This would fix a part bug we had in Backbone-Boilerplate: https://github.com/tbranyen/backbone-boilerplate/issues/199

(I guess to fix this someone need to also republish the fixed version to Jam package repo)
