### PR TITLE
Remove abstraction around '$.contains'

### DIFF
--- a/backbone.layoutmanager.js
+++ b/backbone.layoutmanager.js
@@ -262,7 +262,7 @@ var LayoutManager = Backbone.View.extend({
 
       // If there is a parent, attach.
       if (parent) {
-        if (!options.contains(parent.el, root.el)) {
+        if (!$.contains(parent.el, root.el)) {
           // Apply the partial.
           options.partial(parent.$el, root.$el, rentManager, manager);
         }
@@ -842,12 +842,8 @@ LayoutManager.prototype.options = {
   // By default, render using underscore's templating.
   render: function(template, context) {
     return template(context);
-  },
-
-  // A method to determine if a View contains another.
-  contains: function(parent, child) {
-    return $.contains(parent, child);
   }
+
 };
 
 // Maintain a list of the keys at define time.

--- a/test/dom.js
+++ b/test/dom.js
@@ -44,7 +44,7 @@ asyncTest("afterRender inside Document", function() {
 
     afterRender: function() {
       var doc = document.body;
-      inDocument = this.options.contains(doc, this.el);
+      inDocument = $.contains(doc, this.el);
 
       ok(inDocument, "element in is in the page Document");
 

--- a/test/vendor/util.js
+++ b/test/vendor/util.js
@@ -34,4 +34,5 @@ var testUtil = {
 // module.
 if (testUtil.inNodeJs()) {
   exports.testUtil = testUtil;
+  exports.$ = exports.jQuery = require("cheerio");
 }

--- a/test/views.js
+++ b/test/views.js
@@ -657,7 +657,7 @@ asyncTest("Ensure afterRender can access element's parent.", 1, function() {
     views: {
       ".left": new Backbone.Layout({
         afterRender: function() {
-          ok(this.options.contains(view.el, this.el),
+          ok($.contains(view.el, this.el),
             "Parent can be found in afterRender");
 
           start();
@@ -1278,7 +1278,7 @@ test("attached even if already rendered", 1, function() {
   var layout = new Backbone.Layout();
   layout.setView(view);
 
-  ok(view.options.contains(layout.el, view.el), "View exists inside Layout");
+  ok($.contains(layout.el, view.el), "View exists inside Layout");
 });
 
 test("correctly remove inserted child views", function() {


### PR DESCRIPTION
The `contains` method was made configurable in order to facilitate
running in Node.js. Now that Cheerio supports this method, the
abstraction is no longer technically necessary.

This change will also prevent developers from defining their own custom
`contains` method. Developers have little reason to alter the behavior
of this method, so this feature should go unmissed.
