### PR TITLE
Fix view duplication when rerendering full template

### DIFF
--- a/backbone.layoutmanager.js
+++ b/backbone.layoutmanager.js
@@ -14,7 +14,7 @@ var keys;
 // Localize global dependency references.
 var Backbone = window.Backbone;
 var _ = window._;
-var $ = window.$;
+var $ = Backbone.$;
 
 // Maintain references to the two `Backbone.View` functions that are
 // overwritten so that they can be proxied.
@@ -407,7 +407,11 @@ var LayoutManager = Backbone.View.extend({
         // If no container is specified, we must replace the content.
         if (manager.noel) {
           // Hold a reference to created element as replaceWith doesn't return new el.
-          renderedEl = root.$el.html(rendered).children();
+          renderedEl = $(rendered);
+
+          // Remove extra root elements
+          root.$el.slice(1).remove();
+
           root.$el.replaceWith(renderedEl);
           // Don't delegate events here - we'll do that in resolve()
           root.setElement(renderedEl, false);

--- a/node/index.js
+++ b/node/index.js
@@ -22,11 +22,12 @@ var def = require("underscore.deferred");
 // Get Backbone and _ into the global scope.
 _.defaults(global, { Backbone: Backbone, _: _ });
 
+// Set the Backbone DOM library to be Cheerio.
+Backbone.$ = $;
+
 // Include the LayoutManager source, without eval.
 require("../backbone.layoutmanager");
 
-// Set the Backbone DOM library to be Cheerio.
-Backbone.$ = $;
 
 // Configure LayoutManager with some very useful defaults for Node.js
 // environments.  This allows the end user to simply consume instead of

--- a/test/views.js
+++ b/test/views.js
@@ -1859,3 +1859,23 @@ test("`el: false` with rerendering inserted child views doesn't replicate views"
 
   equal(view.$el.html(), expected.join(''), "the same HTML");
 });
+
+test("`el: false` with non-container element will not be duplicated", 2, function() {
+  var expected = "<p>Paragraph 1</p><p>Paragraph 2</p>",
+    layout = new Backbone.Layout({
+      template: _.template('<div class="layout"><div class="content"></div></div>')
+    }),
+    view = new Backbone.Layout({
+      el: false,
+      template: _.template(expected)
+    });
+
+  layout.setViews({
+    ".content": view
+  }).render().done(function() {
+    equal(layout.$(".content").html(), expected);
+    view.render().done(function() {
+        equal(layout.$(".content").html(), expected);
+    });
+  });
+});


### PR DESCRIPTION
This happens with view with multiple top level elements (fixes bug #299)

The code right now by calling `replaceWith` was looping through all `this.$el` elements, duplicating the views each time it was rerendered. So I just removed the extra elements and replace the first one with the new view. I think right now this is needed as we only have access to the previous `$el` to determine the position of the view in the DOM (But I don't find it really elegant).
