### PR TITLE
Do not reference the template property on a view instance after initialization.

### DIFF
--- a/backbone.layoutmanager.js
+++ b/backbone.layoutmanager.js
@@ -451,7 +451,7 @@ var LayoutManager = Backbone.View.extend({
       // used to know when the element has been rendered into its parent.
       render: function() {
         var context = root.serialize || options.serialize;
-        var template = root.template || options.template;
+        var template = _.result(options.template);
 
         // If data is a function, immediately call it.
         if (_.isFunction(context)) {


### PR DESCRIPTION
This PR implements one of the solutions proposed to the problem outlined in #307.

During initialization the template property at the instance level is deleted: https://github.com/tbranyen/backbone.layoutmanager/blob/master/backbone.layoutmanager.js#L736

Continuing to reference the template property on the view instance can cause problems because `delete` will not recursively remove the property, up the prototype chain. 

I've also wrapped `options.template` in `_.result()` so that the template can be dynamically determined during the render process.
