### PR TITLE
Deleting template property from view instance during initialization is not necessary

### DIFF
--- a/backbone.layoutmanager.js
+++ b/backbone.layoutmanager.js
@@ -731,9 +731,6 @@ var LayoutManager = Backbone.View.extend({
       // Ensure the template is mapped over.
       } else if (view.template) {
         options.template = view.template;
-
-        // Remove it from the instance.
-        delete view.template;
       }
     });
   }

--- a/test/views.js
+++ b/test/views.js
@@ -139,6 +139,39 @@ asyncTest("render inside defined partial", function() {
   });
 });
 
+asyncTest("Subclassed view uses correct template when rendered.", function() {
+  expect(1);
+
+  var layout = new Backbone.Layout();
+  var BaseView = Backbone.View.extend({
+    template: function() {
+      return "Base view template";
+    },
+    manage: true
+  });
+
+  var templateFunction = function() {
+    return 'Extended view template';
+  };
+
+  var ExtendedBaseView = BaseView.extend({
+    constructor: function() {
+      this.template = templateFunction;
+      BaseView.prototype.constructor.apply(this, arguments); 
+    }
+  });
+
+  layout.setView("", new ExtendedBaseView());
+
+  layout.render().then(function() {
+    var view = layout.getView("");
+    var contents = testUtil.trim(this.$el.text());
+      
+    equal(contents, "Extended view template", "Correct template is used");
+    start();
+  });
+});
+
 asyncTest("re-render a view defined after initialization", function(){
   expect(2);
 


### PR DESCRIPTION
`delete view.template` only removes the template property from the
instance's prototype. If the instance inherits from another view that
has a template property this can cause unexpected results during view
rendering.

References #307
