### PR TITLE
Simple helpers extension

### DIFF
--- a/backbone.layoutmanager.js
+++ b/backbone.layoutmanager.js
@@ -440,6 +440,9 @@ var LayoutManager = Backbone.View.extend({
 
       // Render the View into the el property.
       if (contents) {
+        if (options.helpers) {
+          context = _.extend(options.helpers, context);
+        }
         rendered = options.render.call(renderAsync, contents, context);
       }
 


### PR DESCRIPTION
Here's a quick hack to add a simple helpers system. Basically I'm looking for a way to add view "helpers" that are just shared functions available by default to all view templates.

This allows you to add `{helpers: {foo: function() { alert('heya!'); }}` to your Backbone.LayoutManager.configure block and have the function `foo` directly available in all view templates.

This could be far more advanced, but I figured the best way to get a conversation started about adding new features is with working code ;-)
