### PR TITLE
Fix #302

### DIFF
--- a/backbone.layoutmanager.js
+++ b/backbone.layoutmanager.js
@@ -76,7 +76,7 @@ var LayoutManager = Backbone.View.extend({
     // second argument will be used instead.  This is to allow
     // `getViews(undefined, fn)` to work as `getViews(fn)`.  Useful for when
     // you are allowing an optional selector.
-    if (typeof fn !== "function" && typeof fn !== "string") {
+    if (fn == null) {
       fn = arguments[1];
     }
 

--- a/test/views.js
+++ b/test/views.js
@@ -1384,17 +1384,21 @@ test("getView should accept a selector name too", 3, function() {
   equal(view.getViews("c").value().length, 2, "Two Views returned from getViews");
 });
 
-test("getView should accept a `_.where` object too", 3, function() {
+// https://github.com/tbranyen/backbone.layoutmanager/issues/302
+test("getView should accept a `_.where` object too", 4, function() {
   var view = new Backbone.Layout();
 
   var model = new Backbone.Model();
+  var model2 = new Backbone.Model();
 
   var a = view.setView("a", new Backbone.Layout({ model: model }));
   var b = view.setView("b", new Backbone.Layout({ id: 4 }));
+  var d = view.setView("d", new Backbone.Layout({ model: model2 }));
   view.insertView("c", new Backbone.Layout({ model: model }));
   view.insertView("c", new Backbone.Layout({ id: 4 }));
 
   equal(view.getView({ model: model }), a, "Single getView returns single view");
+  equal(view.getView({ model: model2 }), d, "Single getView returns single view");
   equal(view.getViews({ id: 4 }).first().value(), b, "Using getViews will return the single view in an array");
   equal(view.getViews({ id: 4 }).value().length, 2, "Two Views returned from getViews");
 });


### PR DESCRIPTION
Passing a `_.where` object to `getView()` always returned the first subview (matching or not).

Added unit test and a fix.
