### PR TITLE
`el: false` multiple top level (officially not supporting) in 0.8.*

### DIFF
--- a/backbone.layoutmanager.js
+++ b/backbone.layoutmanager.js
@@ -282,7 +282,7 @@ var LayoutManager = Backbone.View.extend({
 
         // If there are multiple top level elements and `el: false` is used,
         // display a warning message and a stack trace.
-        if (manager.noel && root.$el.children().length > 1) {
+        if (manager.noel && root.$el.length > 1) {
           // Do not display a warning while testing or if warning suppression
           // is enabled.
           if (warn && !options.suppressWarnings) { 
@@ -637,6 +637,11 @@ var LayoutManager = Backbone.View.extend({
     if (options.el === false) {
       Backbone.View.prototype.el = false;
     }
+
+    // Allow global configuration of `suppressWarnings`.
+    if (options.suppressWarnings === true) {
+      Backbone.View.prototype.suppressWarnings = true;
+    }
   },
 
   // Configure a View to work with the LayoutManager plugin.
@@ -783,9 +788,10 @@ Backbone.View.prototype._configure = function(options) {
   }
 
   // Assign the `noel` property once we're sure the View we're working with is
-  // mangaed by LayoutManager.
+  // managed by LayoutManager.
   if (this.__manager__) {
     this.__manager__.noel = noel;
+    this.__manager__.suppressWarnings = options.suppressWarnings;
   }
 
   // Act like nothing happened.

--- a/test/dom.js
+++ b/test/dom.js
@@ -1,3 +1,4 @@
+(function(window) {
 "use strict";
 
 QUnit.module("dom", {
@@ -426,3 +427,5 @@ asyncTest("afterRender callback is triggered too early", 2, function() {
     });
   });
 });
+
+})(typeof global !== "undefined" ? global : this);

--- a/test/expose.js
+++ b/test/expose.js
@@ -1,3 +1,4 @@
+(function(window) {
 "use strict";
 
 /* 
@@ -22,3 +23,5 @@ test("attached", 2, function() {
   ok(!_.isFunction(this.LayoutManager),
     "LayoutManager shortcut is not a function");
 });
+
+})(typeof global !== "undefined" ? global : this);

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,3 +1,4 @@
+(function(window) {
 "use strict";
 
 /* 
@@ -96,3 +97,5 @@ test("`setView` exists on `Backbone.View` with `manage:true` set", 1, function()
 
   equal(typeof view.setView, "function", "setView is a function");
 });
+
+})(typeof global !== "undefined" ? global : this);

--- a/test/views.js
+++ b/test/views.js
@@ -1,4 +1,5 @@
-/*jshint QUnit:true, asyncTest:true */
+(function(window) {
+"use strict";
 
 QUnit.module("views", {
   setup: function() {
@@ -94,10 +95,15 @@ QUnit.module("views", {
       }
     });
   },
+
   teardown: function() {
     Backbone.Layout.configure({
       fetch: this.origFetch
     });
+
+    // Remove `supressWarnings: true`.
+    delete Backbone.Layout.prototype.options.suppressWarnings;
+    delete Backbone.View.prototype.suppressWarnings;
   }
 });
 
@@ -1918,3 +1924,5 @@ test("`el: false` with non-container element will not be duplicated", 2, functio
     });
   });
 });
+
+})(typeof global !== "undefined" ? global : this);


### PR DESCRIPTION
Display warnings if using el: false with multiple top level elements, but allow suppression if the end user knows what's up.

This will close https://github.com/tbranyen/backbone.layoutmanager/issues/314 & https://github.com/tbranyen/backbone.layoutmanager/issues/319

This pull request still requires testing and documentation.
