### PR TITLE
trim templates to prevent conflicts with jQuery (fix issue #323)

### DIFF
--- a/backbone.layoutmanager.js
+++ b/backbone.layoutmanager.js
@@ -422,6 +422,7 @@ var LayoutManager = Backbone.View.extend({
     function applyTemplate(rendered) {
       // Actually put the rendered contents into the element.
       if (rendered) {
+        rendered = $.trim(rendered);
         // If no container is specified, we must replace the content.
         if (manager.noel) {
           // Hold a reference to created element as replaceWith doesn't return new el.

--- a/node/index.js
+++ b/node/index.js
@@ -14,6 +14,9 @@ var $ = require("cheerio");
 // `Backbone.View#setElement`.
 $.prototype.unbind = $.prototype.off = function() { return this; };
 
+// Set a basic trim function to allow trimming whitespace from a template
+$.trim = function(str) { return str.trim(); };
+
 // Since jQuery is not being used and LayoutManager depends on a Promise
 // implementation close to jQuery, we use `underscore.deferred` here which
 // matches jQuery's Deferred API exactly.

--- a/test/views.js
+++ b/test/views.js
@@ -1940,4 +1940,23 @@ test("trigger callback on a view with `keep: true`", 1, function() {
   layout.removeView();
 });
 
+// https://github.com/tbranyen/backbone.layoutmanager/issues/323
+test("templates should be trimmed before insertion", 1, function() {
+  var layout = new Backbone.Layout({
+    template: "tpl",
+    el: false,
+    fetch: function() {
+      return "\n <div>Hey</div>\n ";
+    },
+    render: function( tpl ) {
+      return tpl;
+    }
+  });
+
+  layout.render();
+
+  equal(layout.$el.text(), "Hey");
+
+});
+
 })(typeof global !== "undefined" ? global : this);


### PR DESCRIPTION
Hey, I've been looking into issue #323, that's the fix I came up with. Although, I'm not sure this should be added into core; the problem is that the template returned by `fetch` is an invalid _jQuery allowed_ DOM string to generate a new elements.

This is directly related to `el: false` as normal view will only delegate the insertion of new element to `innerHTML` which allow newline and whitespace. `jQuery` constructor does not, so this example only fail when generating a new DOM fragment.

What do you think? cc @tbranyen @jugglinmike 
