### PR TITLE
Fix Layout#getViews for unrecognized selectors

### DIFF
--- a/backbone.layoutmanager.js
+++ b/backbone.layoutmanager.js
@@ -97,9 +97,11 @@ var LayoutManager = Backbone.View.extend({
     }, this).flatten().value();
 
     // If the filter argument is a String, then return a chained Version of the
-    // elements.
+    // elements. The value at the specified filter may be undefined, a single
+    // view, or an array of views; in all cases, chain on a flat array.
     if (typeof fn === "string") {
-      return _.chain([this.views[fn]]).flatten();
+      views = this.views[fn] || [];
+      return _.chain([].concat(views));
     }
 
     // If the argument passed is an Object, then pass it to `_.where`.

--- a/test/views.js
+++ b/test/views.js
@@ -1959,4 +1959,9 @@ test("templates should be trimmed before insertion", 1, function() {
 
 });
 
+test("getViews returns an empty array for unrecognized selectors", function() {
+  var layout = new Backbone.Layout();
+  equal(layout.getViews('.whats-the-buzz').value().length, 0);
+});
+
 })(typeof global !== "undefined" ? global : this);


### PR DESCRIPTION
Return an empty array when no views exist at the specified selector.
Fixes GitHub issue #325.
