### PR TITLE
Bug fix

### DIFF
--- a/backbone.layoutmanager.js
+++ b/backbone.layoutmanager.js
@@ -275,7 +275,7 @@ var LayoutManager = Backbone.View.extend({
       // Reusable function for triggering the afterRender callback and event
       // and setting the hasRendered flag.
       function completeRender() {
-        var afterRender = options.afterRender;
+        var afterRender = root.afterRender ? root.afterRender : options.afterRender;
 
         if (afterRender) {
           afterRender.call(root, root);
@@ -723,7 +723,7 @@ var LayoutManager = Backbone.View.extend({
         // Shorthand the manager.
         var manager = view.__manager__;
         // Cache these properties.
-        var beforeRender = options.beforeRender;
+        var beforeRender = this.beforeRender ? this.beforeRender : options.beforeRender;
 
         // Ensure all nested Views are properly scrubbed if re-rendering.
         if (manager.hasRendered) {


### PR DESCRIPTION
The before and after Render methods did not run, at least when running in AMD, with the old way of creating these in namely:

Backbone.Layout.extend({..., beforeRender(){}, afterRender(){}, ...});

I had to add them via the options route.
