### PR TITLE
Rename fetch render.

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -1,5 +1,5 @@
-# Grunt configuration updated to latest Grunt.  That means your minimum
-# version necessary to run these tasks is Grunt 0.4.
+# Grunt configuration updated to latest Grunt.  That means your minimum version
+# necessary to run these tasks is Grunt 0.4.
 #
 # Please install this locally and install `grunt-cli` globally to run.
 module.exports = ->
@@ -46,8 +46,8 @@ module.exports = ->
         code: "."
         testsDir: "test/"
 
-    # Want to ensure common use cases are accounted for and that we do not
-    # make changes that dramatically impact general performance.
+    # Want to ensure common use cases are accounted for and that we do not make
+    # changes that dramatically impact general performance.
     benchmark:
       options:
         displayResults: true

--- a/backbone.layoutmanager.js
+++ b/backbone.layoutmanager.js
@@ -35,6 +35,50 @@ var aSplice = Array.prototype.splice;
 
 // LayoutManager is a wrapper around a `Backbone.View`.
 var LayoutManager = Backbone.View.extend({
+  _render: function(manage, options) {
+    // Keep the view consistent between callbacks and deferreds.
+    var view = this;
+    // Shorthand the manager.
+    var manager = view.__manager__;
+    // Cache these properties.
+    var beforeRender = options.beforeRender;
+    // Create a deferred instead of going off
+    var def = options.deferred();
+
+    // Ensure all nested Views are properly scrubbed if re-rendering.
+    if (view.hasRendered) {
+      view._removeViews();
+    }
+
+    // This continues the render flow after `beforeRender` has completed.
+    manager.callback = function() {
+      // Clean up asynchronous manager properties.
+      delete manager.isAsync;
+      delete manager.callback;
+
+      // Always emit a beforeRender event.
+      view.trigger("beforeRender", view);
+
+      // Render!
+      manage(view, options).render().then(function() {
+        // Complete this deferred once resolved.
+        def.resolve();
+      });
+    };
+
+    // If a beforeRender function is defined, call it.
+    if (beforeRender) {
+      beforeRender.call(view, view);
+    }
+
+    if (!manager.isAsync) {
+      manager.callback();
+    }
+
+    // Return this intermediary promise.
+    return def.promise();
+  },
+      
   // This named function allows for significantly easier debugging.
   constructor: function Layout(options) {
     // Options may not always be passed to the constructor, this ensures it is
@@ -379,7 +423,7 @@ var LayoutManager = Backbone.View.extend({
 
       // The `_viewRender` method is broken out to abstract away from having
       // too much code in `actuallyRender`.
-      root.render(LayoutManager._viewRender, options).done(function() {
+      root._render(LayoutManager._viewRender, options).done(function() {
         // If there are no children to worry about, complete the render
         // instantly.
         if (!_.keys(root.views).length) {
@@ -516,7 +560,7 @@ var LayoutManager = Backbone.View.extend({
 
       // Render the View into the el property.
       if (contents) {
-        rendered = options.render.call(root, contents, context);
+        rendered = options.renderTemplate.call(root, contents, context);
       }
 
       // If the function was synchronous, continue execution.
@@ -763,64 +807,12 @@ var LayoutManager = Backbone.View.extend({
       // Merge the View options into the View.
       _.extend(view, viewOptions);
 
-      // If the View still has the Backbone.View#render method, remove it.
-      // Don't want it accidentally overriding the LM render.
-      if (viewOverrides.render === LayoutManager.prototype.render ||
-        viewOverrides.render === Backbone.View.prototype.render) {
-        delete viewOverrides.render;
-      }
-
       // Pick out the specific properties that can be dynamically added at
       // runtime and ensure they are available on the view object.
       _.extend(options, viewOverrides);
 
       // By default the original Remove function is the Backbone.View one.
       view._remove = Backbone.View.prototype.remove;
-
-      // Always use this render function when using LayoutManager.
-      view._render = function(manage, options) {
-        // Keep the view consistent between callbacks and deferreds.
-        var view = this;
-        // Shorthand the manager.
-        var manager = view.__manager__;
-        // Cache these properties.
-        var beforeRender = options.beforeRender;
-        // Create a deferred instead of going off
-        var def = options.deferred();
-
-        // Ensure all nested Views are properly scrubbed if re-rendering.
-        if (view.hasRendered) {
-          view._removeViews();
-        }
-
-        // This continues the render flow after `beforeRender` has completed.
-        manager.callback = function() {
-          // Clean up asynchronous manager properties.
-          delete manager.isAsync;
-          delete manager.callback;
-
-          // Always emit a beforeRender event.
-          view.trigger("beforeRender", view);
-
-          // Render!
-          manage(view, options).render().then(function() {
-            // Complete this deferred once resolved.
-            def.resolve();
-          });
-        };
-
-        // If a beforeRender function is defined, call it.
-        if (beforeRender) {
-          beforeRender.call(view, view);
-        }
-
-        if (!manager.isAsync) {
-          manager.callback();
-        }
-
-        // Return this intermediary promise.
-        return def.promise();
-      };
 
       // Ensure the render is always set correctly.
       view.render = LayoutManager.prototype.render;
@@ -910,6 +902,11 @@ LayoutManager.prototype.options = {
     return _.template($(path).html());
   },
 
+  // By default, render using underscore's templating.
+  renderTemplate: function(template, context) {
+    return template(context);
+  },
+
   // This is the most common way you will want to partially apply a view into
   // a layout.
   partial: function($root, $el, rentManager, manager) {
@@ -983,11 +980,6 @@ LayoutManager.prototype.options = {
   // Return a deferred for when all promises resolve/reject.
   when: function(promises) {
     return $.when.apply(null, promises);
-  },
-
-  // By default, render using underscore's templating.
-  render: function(template, context) {
-    return template(context);
   },
 
   // A method to determine if a View contains another.

--- a/test/configure.js
+++ b/test/configure.js
@@ -64,8 +64,10 @@ test("defaults", 18, function() {
   deepEqual(layout.options.prefix, "", "Layout: No prefix");
   // The deferred property should be a function.
   ok(_.isFunction(layout.options.deferred), "Layout: deferred is a function");
-  // The fetch property should be a function.
-  ok(_.isFunction(layout.options.fetch), "Layout: fetch is a function");
+  // The fetchTemplate property should be a function.
+  ok(_.isFunction(layout.options.fetchTemplate), "Layout: fetchTemplate is a function");
+  // The renderTemplate property should be a function.
+  ok(_.isFunction(layout.options.renderTemplate), "Layout: renderTemplate is a function");
   // The partial property should be a function.
   ok(_.isFunction(layout.options.partial), "Layout: partial is a function");
   // The html property should be a function.
@@ -76,14 +78,14 @@ test("defaults", 18, function() {
   ok(_.isFunction(layout.options.insert), "Layout: append is a function");
   // The when property should be a function.
   ok(_.isFunction(layout.options.when), "Layout: when is a function");
-  // The render property should be a function.
-  ok(_.isFunction(layout.options.render), "Layout: render is a function");
   // Paths should be an empty object.
   deepEqual(view.options.prefix, "", "View: No prefix");
   // The deferred property should be a function.
   ok(_.isFunction(view.options.deferred), "View: deferred is a function");
-  // The fetch property should be a function.
-  ok(_.isFunction(view.options.fetch), "View: fetch is a function");
+  // The fetchTemplate property should be a function.
+  ok(_.isFunction(view.options.fetchTemplate), "View: fetchTemplate is a function");
+  // The renderTemplate property should be a function.
+  ok(_.isFunction(view.options.renderTemplate), "View: renderTemplate is a function");
   // The partial property should be a function.
   ok(_.isFunction(view.options.partial), "View: partial is a function");
   // The html property should be a function.
@@ -94,8 +96,6 @@ test("defaults", 18, function() {
   ok(_.isFunction(view.options.insert), "View: append is a function");
   // The when property should be a function.
   ok(_.isFunction(view.options.when), "View: when is a function");
-  // The render property should be a function.
-  ok(_.isFunction(view.options.render), "View: render is a function");
 });
 
 // Test overriding a single property to ensure propagation works as expected.
@@ -153,19 +153,19 @@ test("override at invocation", 3, function() {
 });
 
 // Render broke in 0.5.1 so this test will ensure this always works.
-test("override render", 1, function() {
+test("override renderTemplate", 1, function() {
   var hit = false;
   var layout = new Backbone.Layout({
     template: _.template(testUtil.templates.main),
-    fetch: _.identity,
+    fetchTemplate: _.identity,
 
-    render: function() {
+    renderTemplate: function() {
       hit = true;
     }
   });
 
   layout.render().promise().then(function() {
-    ok(hit, "The render method was hit correctly");
+    ok(hit, "The renderTemplate method was hit correctly");
   });
 });
 
@@ -173,10 +173,10 @@ test("Fetch works on a View during definition", 1, function() {
   var hit = false;
 
   var View = Backbone.Layout.extend({
-    // A template is required to hit fetch.
+    // A template is required to hit fetchTemplate.
     template: "a",
 
-    fetch: function() {
+    fetchTemplate: function() {
       hit = true;
     }
   });
@@ -190,10 +190,10 @@ test("Fetch works on a View during invocation", 1, function() {
   var hit = false;
 
   new Backbone.Layout({
-    // A template is required to hit fetch.
+    // A template is required to hit fetchTemplate.
     template: "a",
 
-    fetch: function() {
+    fetchTemplate: function() {
       hit = true;
     }
   }).render().promise().then(function() {
@@ -213,7 +213,7 @@ test("Collection should exist on the View", 1, function() {
   var V = Backbone.Layout.extend({
     template: "<p></p>",
 
-    fetch: function(path) { return _.template(path); },
+    fetchTemplate: function(path) { return _.template(path); },
 
     initialize: function() {
       this.setViews({
@@ -266,7 +266,7 @@ test("If you use 'data' as a variable in a view it won't render", 1, function() 
 
     data: {},
     serialize: { name: "test" },
-    fetch: _.identity,
+    fetchTemplate: _.identity,
     template: _.template("<%=name%>")
   });
 
@@ -285,10 +285,10 @@ test("View `serialize` not used", 1, function() {
   // Setup View.
   var View = Backbone.Layout.extend({
     template: _.template("<%=top%>"),
-    fetch: _.identity,
+    fetchTemplate: _.identity,
     serialize: { top: false },
 
-    render: function(template, context) {
+    renderTemplate: function(template, context) {
       equal(context.top, false, "Local serialize should override configure");
     }
   });

--- a/test/dom.js
+++ b/test/dom.js
@@ -5,7 +5,7 @@ QUnit.module("dom", {
   setup: function() {
     this.SubView = Backbone.Layout.extend({
       template: _.template(testUtil.templates.testSub),
-      fetch: _.identity,
+      fetchTemplate: _.identity,
 
       serialize: function() {
         return { text: "Right" };
@@ -39,7 +39,7 @@ asyncTest("afterRender inside Document", function() {
   var ProblemView = Backbone.Layout.extend({
     template: "not-real",
 
-    fetch: function() {
+    fetchTemplate: function() {
       setTimeout(this.async(), 10);
     },
 
@@ -56,7 +56,7 @@ asyncTest("afterRender inside Document", function() {
   var NestedView = Backbone.Layout.extend({
     template: "not-real",
 
-    fetch: function() {
+    fetchTemplate: function() {
       setTimeout(this.async(), 10);
     },
 
@@ -68,7 +68,7 @@ asyncTest("afterRender inside Document", function() {
   var NewView = Backbone.Layout.extend({
     template: "not-even-close-to-real",
 
-    fetch: function() {
+    fetchTemplate: function() {
       setTimeout(this.async(), 20);
     }
   });
@@ -108,7 +108,7 @@ test("events not correctly bound", 1, function() {
   var Layout = Backbone.Layout.extend({
     template: "<p></p>",
 
-    fetch: function(name) {
+    fetchTemplate: function(name) {
       return _.template(name);
     },
 
@@ -140,7 +140,7 @@ test("render works when called late", 1, function() {
     template: "<div>Click Here</div>",
     className: "hitMe",
 
-    fetch: function(path) {
+    fetchTemplate: function(path) {
       return _.template(path);
     },
 
@@ -163,7 +163,7 @@ test("render works when called late", 1, function() {
   var layout = new Backbone.Layout({
       template: "<div class='button'></div>",
 
-      fetch: function(path) {
+      fetchTemplate: function(path) {
         return _.template(path);
       },
 
@@ -191,7 +191,7 @@ test("render works when assigned early", 1, function() {
     template: "<div>Click Here</div>",
     className: "hitMe",
 
-    fetch: function(path) {
+    fetchTemplate: function(path) {
       return _.template(path);
     },
 
@@ -212,7 +212,7 @@ test("render works when assigned early", 1, function() {
   var layout = new Backbone.Layout({
       template: "<div class='button'></div>",
 
-      fetch: function(path) {
+      fetchTemplate: function(path) {
         return _.template(path);
       },
 
@@ -237,7 +237,7 @@ test("Ensure events are copied over properly", 1, function() {
   var hit = false;
   var layout = new Backbone.Layout({
     template: "<p></p>",
-    fetch: function(path) { return _.template(path); },
+    fetchTemplate: function(path) { return _.template(path); },
 
     events: {
       "click p": "test"
@@ -262,7 +262,7 @@ asyncTest("events are bound correctly", 1, function() {
 
   var l = new Backbone.Layout({
     template: "<p></p>",
-    fetch: function(path) { return _.template(path); }
+    fetchTemplate: function(path) { return _.template(path); }
   });
 
   l.render();
@@ -270,7 +270,7 @@ asyncTest("events are bound correctly", 1, function() {
   var V = Backbone.Layout.extend({
     keep: true,
     template: "<span>hey</span>",
-    fetch: function(path) { return _.template(path); },
+    fetchTemplate: function(path) { return _.template(path); },
 
     events: {
       click: "hit"
@@ -300,7 +300,7 @@ asyncTest("more events issues", 1, function() {
 
   var V = Backbone.Layout.extend({
     template: "<span>hey</span>",
-    fetch: function(path) { return _.template(path); },
+    fetchTemplate: function(path) { return _.template(path); },
 
     events: {
       click: "hit"
@@ -313,7 +313,7 @@ asyncTest("more events issues", 1, function() {
 
   var S = Backbone.Layout.extend({
     template: "<p></p>",
-    fetch: function(path) { return _.template(path); },
+    fetchTemplate: function(path) { return _.template(path); },
 
     beforeRender: function() {
       // Insert two views.
@@ -348,9 +348,9 @@ asyncTest("more events issues", 1, function() {
   start();
 });
 
-// Explicitly excersize the default `fetch` implementation (most tests override
+// Explicitly excersize the default `fetchTemplate` implementation (most tests override
 // that functionality to use in-memory templates)
-test("default `fetch` method retrieves template from element specified by DOM selector", 1, function() {
+test("default `fetchTemplate` method retrieves template from element specified by DOM selector", 1, function() {
 
   var vyou = new Backbone.Layout({
     template: "#dom-template"
@@ -375,7 +375,7 @@ asyncTest("events delegated correctly when managing your own view element", 1, f
       this.clicked = true;
     },
 
-    template: "item",
+    template: _.template(testUtil.templates.item),
 
     serialize: { text: "lol" }
   });
@@ -393,7 +393,7 @@ asyncTest("afterRender callback is triggered too early", 2, function() {
   var ProblemView = Backbone.Layout.extend({
     template: "not-real",
 
-    fetch: function() {
+    fetchTemplate: function() {
       setTimeout(this.async(), 10);
     },
 
@@ -408,7 +408,7 @@ asyncTest("afterRender callback is triggered too early", 2, function() {
   var NewView = Backbone.Layout.extend({
     template: "not-real",
 
-    fetch: function() {
+    fetchTemplate: function() {
       setTimeout(this.async(), 10);
     },
 

--- a/test/views.js
+++ b/test/views.js
@@ -7,12 +7,12 @@ QUnit.module("views", {
 
     // Override the default template fetching behavior such that the tests can
     // run in the absense of the DOM (for Node.js). Store a reference to the
-    // default `fetch` method to be restored in the teardown of this test
+    // default `fetchTemplate` method to be restored in the teardown of this test
     // module.
-    this.origFetch = Backbone.Layout.prototype.options.fetch;
+    this.origFetch = Backbone.Layout.prototype.options.fetchTemplate;
 
     Backbone.Layout.configure({
-      fetch: function(name) {
+      fetchTemplate: function(name) {
         return _.template(testUtil.templates[name]);
       },
 
@@ -98,7 +98,7 @@ QUnit.module("views", {
 
   teardown: function() {
     Backbone.Layout.configure({
-      fetch: this.origFetch
+      fetchTemplate: this.origFetch
     });
 
     // Remove `supressWarnings: true`.
@@ -746,7 +746,7 @@ asyncTest("Views getting appended in the wrong order", 3, function() {
 
     template: "testing",
 
-    fetch: function(name) {
+    fetchTemplate: function(name) {
       var done = this.async();
 
       setTimeout(function() {
@@ -778,7 +778,7 @@ test("Re-rendering of inserted views causes append at the end of the list", 1, f
 
     template: "<%= msg %>",
 
-    fetch: function(name) {
+    fetchTemplate: function(name) {
       return _.template(name);
     },
 
@@ -793,7 +793,7 @@ test("Re-rendering of inserted views causes append at the end of the list", 1, f
   var list = new Backbone.Layout({
     template: "<tbody></tbody>",
 
-    fetch: function(name) {
+    fetchTemplate: function(name) {
       return _.template(name);
     },
     
@@ -828,7 +828,7 @@ test("afterRender() not called on item added with insertView()", 2, function() {
   var Item = Backbone.Layout.extend({
     template: "",
 
-    fetch: function(path) {
+    fetchTemplate: function(path) {
       return _.template(path);
     },
 
@@ -854,7 +854,7 @@ test("afterRender() not called on item added with insertView()", 2, function() {
   var List = Backbone.Layout.extend({
     template: "<tbody></tbody>",
 
-    fetch: function(path) {
+    fetchTemplate: function(path) {
       return _.template(path);
     },
 
@@ -876,12 +876,12 @@ test("afterRender() not called on item added with insertView()", 2, function() {
 test("Render doesn't work inside insertView", 1, function() {
   var V = Backbone.Layout.extend({
     template: "<p class='inner'><%= lol %></p>",
-    fetch: function(path) { return _.template(path); }
+    fetchTemplate: function(path) { return _.template(path); }
   });
 
   var n = new Backbone.Layout({
     template: "<p></p>",
-    fetch: function(path) { return _.template(path); }
+    fetchTemplate: function(path) { return _.template(path); }
   });
 
   n.render();
@@ -912,14 +912,14 @@ test("afterRender not firing", 1, function() {
   var hit = false;
   var l = new Backbone.Layout({
     template: "<p></p>",
-    fetch: function(path) { return _.template(path); }
+    fetchTemplate: function(path) { return _.template(path); }
   });
 
   l.render();
 
   var V = Backbone.Layout.extend({
     template: "<span>hey</span>",
-    fetch: function(path) { return _.template(path); },
+    fetchTemplate: function(path) { return _.template(path); },
 
     afterRender: function() {
       hit = true;
@@ -935,7 +935,7 @@ test("multiple subclasses afterRender works", 1, function() {
   var hit = 0;
   var SubClass1 = Backbone.Layout.extend({
     template: "<p></p>",
-    fetch: function(path) { return _.template(path); },
+    fetchTemplate: function(path) { return _.template(path); },
 
     afterRender: function() {
       hit--;
@@ -944,7 +944,7 @@ test("multiple subclasses afterRender works", 1, function() {
 
   var SubClass2 = SubClass1.extend({
     template: "<p></p>",
-    fetch: function(path) { return _.template(path); },
+    fetchTemplate: function(path) { return _.template(path); },
 
     afterRender: function lol() {
       hit++;
@@ -953,7 +953,7 @@ test("multiple subclasses afterRender works", 1, function() {
 
   var ParentTest = Backbone.Layout.extend({
     template: "<p></p>",
-    fetch: function(path) { return _.template(path); },
+    fetchTemplate: function(path) { return _.template(path); },
 
     beforeRender: function() {
       this.setView("", new SubClass2());
@@ -962,7 +962,7 @@ test("multiple subclasses afterRender works", 1, function() {
 
   var Test = Backbone.Layout.extend({
     template: "<p></p>",
-    fetch: function(path) { return _.template(path); },
+    fetchTemplate: function(path) { return _.template(path); },
 
     triggerRender: function() {
       this.insertView("p", new ParentTest()).render();
@@ -1000,8 +1000,8 @@ test("Views cannot be removed once added to a Layout", 3, function() {
 
 // https://github.com/tbranyen/backbone.layoutmanager/issues/150
 asyncTest("Views intermittently render multiple times", 1, function() {
-  // Simulating fetch, should only execute once per template and then cache.
-  function fetch(name) {
+  // Simulating fetchTemplate, should only execute once per template and then cache.
+  function fetchTemplate(name) {
     var done = this.async();
     
     setTimeout(function() {
@@ -1020,12 +1020,12 @@ asyncTest("Views intermittently render multiple times", 1, function() {
 
   var View1 = Backbone.Layout.extend({
     template: "view1",
-    fetch: fetch
+    fetchTemplate: fetchTemplate
   });
 
   var ListItem = Backbone.Layout.extend({
     template: "listItem",
-    fetch: fetch,
+    fetchTemplate: fetchTemplate,
 
     serialize: function() {
       return { item: this.model.get("item") };
@@ -1034,7 +1034,7 @@ asyncTest("Views intermittently render multiple times", 1, function() {
 
   var View2 = Backbone.Layout.extend({
     template: "view2",
-    fetch: fetch,
+    fetchTemplate: fetchTemplate,
       
     beforeRender: function() {
       this.collection.each(function(model) {
@@ -1045,12 +1045,12 @@ asyncTest("Views intermittently render multiple times", 1, function() {
 
   var View3 = Backbone.Layout.extend({
     template: "view3",
-    fetch: fetch
+    fetchTemplate: fetchTemplate
   });
 
   var main = new Backbone.Layout({
     template: "view0",
-    fetch: fetch
+    fetchTemplate: fetchTemplate
   });
 
   main.setView(".view0", new View1());
@@ -1075,7 +1075,7 @@ test("remove method not working as expected", function() {
 
   var list = new Backbone.Layout({
     template: "<ul></ul>",
-    fetch: function(path) { return _.template(path); },
+    fetchTemplate: function(path) { return _.template(path); },
 
     views: {
       "ul": [
@@ -1112,7 +1112,7 @@ asyncTest("beforeRender and afterRender called twice in async", 3, function() {
   var Item = Backbone.Layout.extend({
     template: "lol",
 
-    fetch: function(path) {
+    fetchTemplate: function(path) {
       var done = this.async();
 
       setTimeout(function() {
@@ -1130,7 +1130,7 @@ asyncTest("beforeRender and afterRender called twice in async", 3, function() {
       hitAfter = hitAfter + 1;
     },
     
-    render: function(tmpl, data) {
+    renderTemplate: function(tmpl, data) {
       renderNum++;
       return tmpl(data);
     },
@@ -1143,7 +1143,7 @@ asyncTest("beforeRender and afterRender called twice in async", 3, function() {
   var List = Backbone.Layout.extend({
     template: "<tbody></tbody>",
 
-    fetch: function(path) {
+    fetchTemplate: function(path) {
       var done = this.async();
 
       setTimeout(function() {
@@ -1335,7 +1335,7 @@ test("correctly remove inserted child views", function() {
 
     template: "<%= msg %>",
 
-    fetch: function(name) {
+    fetchTemplate: function(name) {
       return _.template(name);
     },
 
@@ -1352,7 +1352,7 @@ test("correctly remove inserted child views", function() {
   var list = new Backbone.Layout({
     template: "<tbody></tbody>",
 
-    fetch: function(name) {
+    fetchTemplate: function(name) {
       return _.template(name);
     },
     
@@ -1440,9 +1440,9 @@ asyncTest("Allow async custom rendering of templates", 1, function() {
   var Test = Backbone.View.extend({
     manage: true,
     template: "Hello World!",
-    fetch: _.identity,
+    fetchTemplate: _.identity,
 
-    render: function(template, data) {
+    renderTemplate: function(template, data) {
       var done = this.async();
 
       setTimeout(function() {
@@ -1464,7 +1464,7 @@ test("cleanup hit", 1, function() {
   var View = Backbone.View.extend({
     manage: true,
 
-    render: function() {
+    renderTemplate: function() {
       ok(false);
     },
 
@@ -1483,11 +1483,11 @@ test("cleanup hit", 1, function() {
 
 asyncTest("Duplicate sub-views are removed when their parent view is rendered repeatedly", 1, function() {
   var ListItemView = Backbone.Layout.extend({
-    // Set a template source so Layout calls this view's `fetch` method
+    // Set a template source so Layout calls this view's `fetchTemplate` method
     // (the actual value is unimportant for this test)
     template: "#bogus",
-    // Generic asynchronous `fetch` method
-    fetch: function(name) {
+    // Generic asynchronous `fetchTemplate` method
+    fetchTemplate: function(name) {
       var done = this.async();
       setTimeout(function() {
         done(_.template(""));
@@ -1511,7 +1511,7 @@ asyncTest("Duplicate sub-views are removed when their parent view is rendered re
 test("Scoping nested view assignment selector to parent", 1, function() {
   var layout = new Backbone.Layout({
     template: _.template("<div class='test'></div>"),
-    fetch: _.identity,
+    fetchTemplate: _.identity,
 
     views: {
       ".test": new Backbone.Layout({
@@ -1681,12 +1681,12 @@ asyncTest("Ordering sub-views with varying render delays", 1, function() {
   var Outside = Backbone.View.extend({
     manage: true,
     template: "[outside]",
-    fetch: _.template
+    fetchTemplate: _.template
   });
   var Inside = Backbone.View.extend({
     manage: true,
     template: "[inside]",
-    fetch: function(str) {
+    fetchTemplate: function(str) {
       var done = this.async();
       setTimeout(function() {
         done(_.template(str));
@@ -1944,10 +1944,10 @@ test("templates should be trimmed before insertion", 1, function() {
   var layout = new Backbone.Layout({
     template: "tpl",
     el: false,
-    fetch: function() {
+    fetchTemplate: function() {
       return "\n <div>Hey</div>\n ";
     },
-    render: function( tpl ) {
+    renderTemplate: function( tpl ) {
       return tpl;
     }
   });
@@ -2080,14 +2080,14 @@ test("removeView fails if no subView exists.", 1, function() {
   }
 });
 
-// Ensure non-function, non-string, values are passed to `fetch`.
+// Ensure non-function, non-string, values are passed to `fetchTemplate`.
 test("object template", 1, function() {
   var testObject = { contents: "Here" };
 
   var View = Backbone.Layout.extend({
     template: testObject,
 
-    fetch: function(template) {
+    fetchTemplate: function(template) {
       equal(template, testObject, "Correct object is passed");
     }
   });
@@ -2120,7 +2120,7 @@ asyncTest("renderViews will only render the children and not parent", 2, functio
 
     template: "hello",
 
-    fetch: function(template) {
+    fetchTemplate: function(template) {
       var done = this.async();
 
       // Simulate async.
@@ -2154,7 +2154,7 @@ test("'insertView' uses user-defined `insert` method on parent", 2, function() {
   var hit = false;
   var layout = new Backbone.Layout({
     template: _.template("<div class='test'>Hello</div>"),
-    fetch: _.identity,
+    fetchTemplate: _.identity,
     insert: function($root, child){
       child = Backbone.$(child).prepend("<div>There</div>");
       $root.append(child);
@@ -2178,7 +2178,7 @@ test("'setView' uses user-defined `html` method on parent", 5, function() {
   var hit = 0, childHit = 0;
   var layout = new Backbone.Layout({
     template: _.template("<div class='test'>Hello</div>"),
-    fetch: _.identity,
+    fetchTemplate: _.identity,
     html: function($root, content){
       content = Backbone.$(content).prepend("<b>Big</b>");
       $root.html(content);
@@ -2192,7 +2192,7 @@ test("'setView' uses user-defined `html` method on parent", 5, function() {
 
   layout.setView(".test", new Backbone.Layout({
     template: _.template("<span>World</span>"),
-    fetch: _.identity,
+    fetchTemplate: _.identity,
     html: function($root, content){
       content = Backbone.$(content).prepend("<b>Huge</b>");
       $root.html(content);


### PR DESCRIPTION
It was always confusing as to which `render` method you were actually modifying.  I've made it significantly clearer with this PR.  Now it is `fetchTemplate` and `renderTemplate`.  I also broke out `_render` and put it on the `Backbone.Layout.prototype`.

I also updated all the unit tests to reflect this change.

What do you guys think? Should I rename `fetch` as well? This feels like a consistent change, but also an annoying one to upgrade.
