### PR TITLE
Fix usage of `insert` flag (should be in parent manager).

### DIFF
--- a/backbone.layoutmanager.js
+++ b/backbone.layoutmanager.js
@@ -344,7 +344,7 @@ var LayoutManager = Backbone.View.extend({
       // method (single view), attach.
       if (parent && !manager.insertedViaFragment) {
         if (!options.contains(parent.el, root.el)) {
-          // Apply the partial using parent's html() or insert() method.
+          // Apply the partial using parent's html() method.
           parent.getAllOptions().partial(parent.$el, root.$el, rentManager,
             manager);
         }
@@ -916,8 +916,8 @@ LayoutManager.prototype.options = {
       }
     }
 
-    // Use the insert method if insert argument is true.
-    if (manager.insert) {
+    // Use the insert method if the parent's `insert` argument is true.
+    if (rentManager.insert) {
       this.insert($root, $el);
     } else {
       this.html($root, $el);
@@ -940,8 +940,8 @@ LayoutManager.prototype.options = {
     // Shorthand the parent manager object.
     var rentManager = rootView.__manager__;
     // Create a simplified manager object that tells partial() where
-    // place the elements and whether to use html() or insert().
-    var manager = { selector: selector, insert: rentManager.insert };
+    // place the elements.
+    var manager = { selector: selector };
 
     // Get the elements to be inserted into the root view.
     var els = _.reduce(subViews, function(memo, sub) {

--- a/node/index.js
+++ b/node/index.js
@@ -83,8 +83,8 @@ Backbone.Layout.configure({
       return false;
     }
 
-    // Use the insert method if `insert` argument is true.
-    if (manager.insert) {
+    // Use the insert method if the parent's `insert` argument is true.
+    if (rentManager.insert) {
       this.insert($root, $el);
     } else {
       this.html($root, $el);


### PR DESCRIPTION
`partial` is only used in an insert context by `htmlBatch` - all other calls to `partial` are done by `setView`, either right away if the view has already rendered or after rendering.

This removes the hacky translation of the `insert` flag in `htmlBatch`.
