### PR TITLE
Added cleanUp event

### DIFF
--- a/backbone.layoutmanager.js
+++ b/backbone.layoutmanager.js
@@ -715,6 +715,9 @@ var LayoutManager = Backbone.View.extend({
     _.each(aConcat.call([], views), function(view) {
       var cleanup;
 
+      // Fire a cleanup event before all events are removed.
+      view.trigger("cleanUp");
+
       // Remove all custom events attached to this View.
       view.unbind();
 


### PR DESCRIPTION
Came across a situation where a model needed to be destroyed once the view had been removed. Adding the cleanUp event allowed me to destroy the views model before removing it. May be useful for someone else.
