### PR TITLE
Added insertView `insertAt` option for inserting a view at a given index.

### DIFF
--- a/backbone.layoutmanager.js
+++ b/backbone.layoutmanager.js
@@ -276,7 +276,7 @@ var LayoutManager = Backbone.View.extend({
 
     // If no `view` argument is defined, then assume the first argument is the
     // View, somewhat now confusingly named `selector`.
-    return this.setView(selector, true, options);
+    return this.setView(selector, true, view);
   },
 
   // Iterate over an object and ensure every value is wrapped in an array to
@@ -367,6 +367,7 @@ var LayoutManager = Backbone.View.extend({
 
     // If no name was passed, use an empty string and shift all arguments.
     if (typeof name !== "string") {
+      insertOptions = insert;
       insert = view;
       view = name;
       name = "";

--- a/test/spec/views.js
+++ b/test/spec/views.js
@@ -2237,6 +2237,74 @@ test("A view's 'views' option should auto-invoke passed functions.", 3, function
   });
 });
 
+test("`insertAt` parameter to View#insertView", 8, function() {
+  var Child = Backbone.Layout.extend({
+    template: _.template("<div class=\"child\"></div>"),
+    afterRender: function(){
+      this.$(".child").addClass("index-" + this.options.index);
+    }
+  });
+  var Parent = Backbone.Layout.extend({
+    id: "wrapper",
+    template: _.template("<div class=\"parent\"></div>"),
+    views: {
+      ".parent" : [
+        new Child({index: 1}),
+        new Child({index: 2})
+      ]
+    }
+  });
+
+  var view = new Parent();
+  view.render();
+
+  var expected1 = [
+    "<div class=\"parent\">",
+      "<div><div class=\"child index-1\"></div></div>",
+      "<div><div class=\"child index-2\"></div></div>",
+    "</div>"
+  ];
+  equal(view.$el.html(), expected1.join(""), "expected HTML before an insert");
+  
+  // Insert a few
+
+  // beginning
+  view.insertView(".parent", new Child({index: 3}), {insertAt: 0}).render();
+  // end
+  view.insertView(".parent", new Child({index: 4}), {insertAt: 3}).render();
+  // high index
+  view.insertView(".parent", new Child({index: 5}), {insertAt: 10}).render();
+  // neg index (one from end as in Array#splice)
+  view.insertView(".parent", new Child({index: 6}), {insertAt: -1}).render();
+
+  var expected2 = [
+    "<div class=\"parent\">",
+      "<div><div class=\"child index-3\"></div></div>",
+      "<div><div class=\"child index-1\"></div></div>",
+      "<div><div class=\"child index-2\"></div></div>",
+      "<div><div class=\"child index-4\"></div></div>",
+      "<div><div class=\"child index-6\"></div></div>",
+      "<div><div class=\"child index-5\"></div></div>",
+    "</div>"
+  ];
+  equal(view.$el.html(), expected2.join(""),
+    "expected HTML after a few targeted inserts");
+  ok(view.views[".parent"][0].$el.find(".index-3").length,
+    "element 3 is correctly inserted in parent.views array");
+  ok(view.views[".parent"][1].$el.find(".index-1").length,
+    "element 1 is correctly inserted in parent.views array");
+  ok(view.views[".parent"][2].$el.find(".index-2").length,
+    "element 2 is correctly inserted in parent.views array");
+  ok(view.views[".parent"][3].$el.find(".index-4").length,
+    "element 4 is correctly inserted in parent.views array");
+  ok(view.views[".parent"][4].$el.find(".index-6").length,
+    "element 6 is correctly inserted in parent.views array");
+  ok(view.views[".parent"][5].$el.find(".index-5").length,
+    "element 5 is correctly inserted in parent.views array");
+
+});
+
+
 })();
 
 // https://github.com/tbranyen/backbone.layoutmanager/issues/383


### PR DESCRIPTION
(Moved from #348, #350)

It is often useful to update a collection of views in place without rerendering the bunch.

A simple way of doing that is the following code:

``` javascript
parentView.insertView('.container', new ChildView()).render() // renders child at bottom
```

The above code will not rerender the entire parent view, but successfully inserts a new view and appends it to the bottom of `.container`.

This patch adds an optional `insertAt` parameter as an options key (for readability, I dislike magic-looking numbers) that indicates where the inserted view should be placed. If 0, it is at the beginning of the list; if > list.length, it is at the end; if negative, it is counted backwards from the end of the list. Behavior mirrors Array#splice.

``` javascript
parentView.insertView('.container', new ChildView(), {insertAt: 1}).render(); // renders after first item
```

Tests are included.
