### PR TITLE
Move qunit to a development dependency in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,9 @@
     "jquery": ">=1.6",
     "underscore": ">=1.5",
     "backbone": "~1.0",
-    "qunit": "~1.12.0",
     "requirejs": "~2.1.8"
+  },
+  "devDependencies": {
+    "qunit": "~1.12.0"
   }
 }


### PR DESCRIPTION
qunit isn't required to use layoutmanager, only to run the test suite during development.  Specifying it as a devDependency seems more accurate and will save people installing qunit when not developing layoutmanager.
