### PR TITLE
make default serialize method work with plain model

### DIFF
--- a/backbone.layoutmanager.js
+++ b/backbone.layoutmanager.js
@@ -903,7 +903,11 @@ LayoutManager.prototype.options = {
 
   // By default, pass model attributes to the templates
   serialize: function() {
-    return this.model ? _.clone(this.model.attributes) : {};
+    if (this.model) {
+      return _.clone(this.model instanceof Backbone.Model ? this.model.attributes : this.model);
+    } else {
+      return {};
+    }
   },
 
   // This is the most common way you will want to partially apply a view into


### PR DESCRIPTION
I'm not sure if this helpful or not. If yes - I will prepare all other things. Just take a look and review. Thanks.

Doing

```
  this.insertView(new UserView({model:{name: "John"}}));
```

won't render "John", because default serialize method expect Model object.
It is not convenient, in my opinion.
