### PR TITLE
Increase platform coverage on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,12 @@ language: node_js
 node_js:
   - 0.8
   - "0.10"
+  - 0.11
 branches:
   only:
     - master
     - wip
+matrix:
+  fast_finish: true
+  allow_failures:
+    - node_js: 0.11


### PR DESCRIPTION
Originally, I just wanted to test LayoutManager against Node.js v0.11, but then I realized we're not even testing against 0.10.
