### PR TITLE
Ensure options object is cloned when used, instead of attached directly.

### DIFF
--- a/backbone.layoutmanager.js
+++ b/backbone.layoutmanager.js
@@ -731,8 +731,9 @@ var LayoutManager = Backbone.View.extend({
 
   // Configure a View to work with the LayoutManager plugin.
   setupView: function(views, options) {
-    // Don't break the options object (passed into Backbone.View#initialize).
-    options = options || {};
+    // Ensure that options is always an object, and clone it so that
+    // changes to the original object don't screw up this view.
+    options = _.extend({}, options);
 
     // Set up all Views passed.
     _.each(aConcat.call([], views), function(view) {

--- a/test/spec/views.js
+++ b/test/spec/views.js
@@ -2308,3 +2308,12 @@ test("not attached even if already rendered", 1, function() {
 
   ok(!view.contains(layout.el, view.el), "View should not exist inside Layout");
 });
+
+test("Modifications to options after initialization should not modify a view", 1, function() {
+  var options = {
+    option: "value"
+  };
+  var layout = new Backbone.Layout(options);
+  options.option = "changedValue";
+  equal(layout.options.option, "value");
+});


### PR DESCRIPTION
This prevents modifications on the passed-in options object from changing options on the view.

Without it, the attached test case will fail, leading to some pretty bizarre and hard-to-find bugs.
