### PR TITLE
Remove Coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ branches:
     - wip
 
 before_install:
-  - npm install -g bower coveralls grunt-cli
+  - npm install -g bower grunt-cli
   - npm install
   - bower install
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ LayoutManager
 Status](https://travis-ci.org/tbranyen/backbone.layoutmanager.png?branch=master)](https://travis-ci.org/tbranyen/backbone.layoutmanager)
 [![Dependency
 Status](https://gemnasium.com/tbranyen/backbone.layoutmanager.png)](https://gemnasium.com/tbranyen/backbone.layoutmanager)
-[![Coverage
-Status](https://coveralls.io/repos/tbranyen/backbone.layoutmanager/badge.png?branch=master)](https://coveralls.io/r/tbranyen/backbone.layoutmanager?branch=master)
 
 Maintained by Tim Branyen [@tbranyen](http://twitter.com/tbranyen), Mike
 Pennisi [@jugglinmike](http://twitter.com/jugglinmike), Simon Boudrias

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "grunt-jscs-checker": "~0.3.2"
   },
   "scripts": {
-    "test": "grunt && cat test/report/lcov.info | coveralls"
+    "test": "grunt"
   },
   "jam": {
     "dependencies": {


### PR DESCRIPTION
The Coveralls service regularly fails due to problems which are
unrelated to this project.

Example failure from [a recent TravisCI job](https://travis-ci.org/tbranyen/backbone.layoutmanager/jobs/20301855):

```
Done, without errors.
[warn] "2014-03-07T18:05:57.632Z"  'Repo token could not be determined.  Continuing without it.'
/home/travis/.nvm/v0.11.11/lib/node_modules/coveralls/bin/coveralls.js:18
        throw err;
              ^
Bad response: 503 <!DOCTYPE html>
    <html>
    <head>
      <style type="text/css">
        html, body, iframe { margin: 0; padding: 0; height: 100%; }
        iframe { display: block; width: 100%; border: none; }
      </style>
    <title>Application Error</title>
    </head>
    <body>
      <iframe src="https://s3.amazonaws.com/assets.coveralls.io/maintenance.html">
        <p>Application Error</p>
      </iframe>
    </body>
    </html>
npm ERR! Test failed.  See above for more details.
npm ERR! not ok code 0
The command "npm test" exited with 1.
Done. Your build exited with 1.
```

/cc @lemurheavy
