### PR TITLE
Update jscs version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "grunt-qunit-istanbul": "~0.3.0",
     "grunt-nodequnit": "~0.2.0",
     "grunt-benchmark": "~0.2.0",
-    "grunt-jscs-checker": "~0.3.2"
+    "grunt-jscs-checker": "~0.4.1"
   },
   "scripts": {
     "test": "grunt"


### PR DESCRIPTION
Previous version had a peerDependency on grunt (0.4.2 exact) that was too strict,
causing errors when running npm install in this repo.
