### PR TITLE
Add browserify support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 node_modules
 test/report
+test/tmp
+test/index-*.html
 bower_components
+build/backbone.layoutmanager.bundle.js

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -5,6 +5,8 @@ module.exports = ->
     "clean"
     "jscs"
     "jshint"
+    "browserify"
+    "targethtml"
     "qunit"
     "nodequnit"
   ]

--- a/backbone.layoutmanager.js
+++ b/backbone.layoutmanager.js
@@ -3,20 +3,26 @@
  * Copyright 2013, Tim Branyen (@tbranyen)
  * backbone.layoutmanager.js may be freely distributed under the MIT license.
  */
-(function(window, factory) {
+(function(root, factory) {
   "use strict";
-  var Backbone = window.Backbone;
-
-  // AMD. Register as an anonymous module.  Wrap in function so we have access
-  // to root via `this`.
   if (typeof define === "function" && define.amd) {
-    return define(["backbone", "underscore", "jquery"], function() {
-      return factory.apply(window, arguments);
+    // AMD. Register as an anonymous module.
+    define(["backbone", "underscore", "jquery"], function() {
+      return factory.apply(root, arguments);
     });
+  } else if (typeof exports === "object") {
+    /* jshint node:true */
+    // Node. Does not work with strict CommonJS, but
+    // only CommonJS-like environments that support module.exports,
+    // like Node.
+    require("./node/node-shim");
+    module.exports = factory.call(root, require("backbone"),
+      require("underscore"), require("backbone").$);
+  } else {
+    // Browser globals (root is window)
+    var Backbone = window.Backbone;
+    Backbone.Layout = factory.call(root, Backbone, window._, Backbone.$);
   }
-
-  // Browser globals.
-  Backbone.Layout = factory.call(window, Backbone, window._, Backbone.$);
 }(typeof global === "object" ? global : this, function (Backbone, _, $) {
 "use strict";
 
@@ -962,6 +968,11 @@ var defaultOptions = {
 
 // Extend LayoutManager with default options.
 _.extend(LayoutManager.prototype, defaultOptions);
+
+// Write additional defaults for node environments.
+if (typeof exports === "object"){
+  require("./node/node-configure");
+}
 
 // Assign `LayoutManager` object for AMD loaders.
 return LayoutManager;

--- a/build/tasks/browserify.coffee
+++ b/build/tasks/browserify.coffee
@@ -1,0 +1,9 @@
+module.exports = ->
+
+  @config "browserify",
+
+    dist:
+      src: 'backbone.layoutmanager.js',
+      dest: 'build/backbone.layoutmanager.bundle.js'
+
+  @loadNpmTasks "grunt-browserify"

--- a/build/tasks/jshint.coffee
+++ b/build/tasks/jshint.coffee
@@ -6,7 +6,7 @@ module.exports = ->
 
     node:
       files:
-        src: ["node/index.js"]
+        src: ["node/*.js"]
 
       options:
         node: true

--- a/build/tasks/qunit.coffee
+++ b/build/tasks/qunit.coffee
@@ -12,6 +12,7 @@ module.exports = ->
         lcovReport: "test/report"
         linesThresholdPct: 85
 
-    files: ["test/index.html"]
+    browser: ["test/index.html"] 
+    browserify: ["test/index-browserify.html"]
 
   @loadNpmTasks "grunt-qunit-istanbul"

--- a/build/tasks/targethtml.coffee
+++ b/build/tasks/targethtml.coffee
@@ -1,0 +1,10 @@
+module.exports = ->
+
+  @config "targethtml",
+
+    # Create browserify test file so we don't have to repeat ourselves
+    browserify:
+      files:
+        'test/index-browserify.html': 'test/index.html'
+
+  @loadNpmTasks "grunt-targethtml"

--- a/node/node-configure.js
+++ b/node/node-configure.js
@@ -1,36 +1,18 @@
-var fs = require("fs");
+/* jshint node:true */
 
-// Common dependencies to get LayoutManager running.
+// Don't run this configuration inside browserify.
+if (process.browser) {
+  return;
+}
+
 var Backbone = require("backbone");
 var _ = require("underscore");
-
-// Using Cheerio instead of jQuery, because Cheerio emulates a loosely
-// compatible API that we further augment to ensure unit tests pass.  It is
-// also much faster than jsdom.
-var $ = require("cheerio");
-
-// This is to avoid unwanted errors thrown when using
-// `Backbone.View#setElement`.
-$.prototype.unbind = $.prototype.off = function() { return this; };
-
-// Since jQuery is not being used and LayoutManager depends on a Promise
-// implementation close to jQuery, we use `underscore.deferred` here which
-// matches jQuery's Deferred API exactly.  This is mixed into Cheerio to make
-// it more seamless.
-_.extend($, require("underscore.deferred"));
-
-// Get Backbone and _ into the global scope.
-_.defaults(global, { Backbone: Backbone, _: _ });
-
-// Set the Backbone DOM library to be Cheerio.
-Backbone.$ = $;
-
-// Include the LayoutManager source, without eval.
-require("../backbone.layoutmanager");
+var fs = require("fs");
 
 // Configure LayoutManager with some very useful defaults for Node.js
 // environments.  This allows the end user to simply consume instead of
 // fighting with the desirable configuration.
+
 Backbone.Layout.configure({
   // Sensible default for Node.js is to load templates from the filesystem.
   // This is similar to how we default to script tags in browser-land.
@@ -59,5 +41,3 @@ Backbone.Layout.configure({
     });
   }
 });
-
-module.exports = Backbone.Layout;

--- a/node/node-shim.js
+++ b/node/node-shim.js
@@ -1,0 +1,34 @@
+/* jshint node:true */
+// Common dependencies to get LayoutManager running.
+var Backbone = require("backbone");
+var _ = require("underscore");
+
+// Using Cheerio instead of jQuery, because Cheerio emulates a loosely
+// compatible API that we further augment to ensure unit tests pass.  It is
+// also much faster than jsdom.
+// If this is browserify, this will resolve to jquery.
+var $ = require("cheerio");
+
+// If we're in a raw node environment (not browserify), we need to juggle
+// a few dependencies. Inside package.json, we use the "browser" config
+// to use jquery instead of cheerio so everything works right in the browser.
+if (!process.browser){
+  // This is to avoid unwanted errors thrown when using
+  // `Backbone.View#setElement`.
+  $.prototype.unbind = $.prototype.off = function() { return this; };
+
+  // Since jQuery is not being used and LayoutManager depends on a Promise
+  // implementation close to jQuery, we use `underscore.deferred` here which
+  // matches jQuery's Deferred API exactly.  This is mixed into Cheerio to make
+  // it more seamless.
+  _.extend($, require("underscore.deferred"));
+} else {
+  // In browserify, put jquery into the global scope if it's not there already.
+  _.defaults(global, { $: $ });
+}
+
+// Get Backbone and _ into the global scope.
+_.defaults(global, { Backbone: Backbone, _: _ });
+
+// Set the Backbone DOM library to be Cheerio/jQuery.
+Backbone.$ = $;

--- a/package.json
+++ b/package.json
@@ -8,8 +8,10 @@
     "type": "git",
     "url": "git://github.com/tbranyen/backbone.layoutmanager.git"
   },
-  "main": "node/index",
-  "browser": "./backbone.layoutmanager.js",
+  "main": "backbone.layoutmanager.js",
+  "browser": {
+    "cheerio": "./bower_components/jquery/dist/jquery.js"
+  },
   "engines": {
     "node": ">=0.8"
   },

--- a/test/index.html
+++ b/test/index.html
@@ -7,17 +7,25 @@
   <!-- Bower components -->
   <link rel="stylesheet" href="../bower_components/qunit/qunit/qunit.css">
   <script src="../bower_components/qunit/qunit/qunit.js"></script>
-  <script src="../bower_components/jquery/dist/jquery.js"></script>
-  <script src="../bower_components/underscore/underscore.js"></script>
-  <script src="../bower_components/backbone/backbone.js"></script>
-  <script src="../backbone.layoutmanager.js"></script>
-  <script src="../bower_components/requirejs/require.js"></script>
+  <!--(if target dev)><!-->
+    <script src="../bower_components/jquery/dist/jquery.js"></script>
+    <script src="../bower_components/underscore/underscore.js"></script>
+    <script src="../bower_components/backbone/backbone.js"></script>
+    <script src="../backbone.layoutmanager.js"></script>
+    <script src="../bower_components/requirejs/require.js"></script>
+  <!--<!(endif)-->
+  <!--(if target browserify)>
+    <script src="../build/backbone.layoutmanager.bundle.js"></script>
+  <!<!(endif)-->
+
 
   <!-- Util scripts -->
   <script src="util/util.js"></script>
 
   <!-- Test scripts -->
-  <script src="spec/expose.js"></script>
+  <!--(if target dev)><!-->
+    <script src="spec/expose.js"></script>
+  <!--<!(endif)-->
   <script src="spec/configure.js"></script>
   <script src="spec/setup.js"></script>
   <script src="spec/views.js"></script>


### PR DESCRIPTION
This addresses #429. I've juggled the UMD definition and split out the node shims into two parts: one that manages dependencies (cheerio, `$.fn.unbind`, etc), and another that manages sensible Node defaults (`fetchTemplate`, etc). 

`grunt-targethtml` generates another QUnit test suite that tests the browserify-compiled version of LM. 
