### PR TITLE
Fix bug in `setView`

### DIFF
--- a/backbone.layoutmanager.js
+++ b/backbone.layoutmanager.js
@@ -392,8 +392,11 @@ var LayoutManager = Backbone.View.extend({
     // Code path is less complex for Views that are not being inserted.  Simply
     // remove existing Views and bail out with the assignment.
     if (!insert) {
-      // Ensure remove is called when swapping View's.
-      root.removeView(name);
+      // Ensure remove is called only when swapping in a new view (when the
+      // view is the same, it does not need to be removed or cleaned up).
+      if (root.getView(name) !== view) {
+        root.removeView(name);
+      }
 
       // Assign to main views object and return for chainability.
       return root.views[selector] = view;

--- a/test/spec/views.js
+++ b/test/spec/views.js
@@ -2328,3 +2328,37 @@ test("template method context", 1, function() {
 
   layout.render();
 });
+
+QUnit.module("setView");
+
+test("Does not remove child's children", 1, function() {
+  var Test = Backbone.Layout.extend({ template: "" });
+  var parent = new Test();
+  var child = new Test();
+  var grandchild = new Test();
+
+  child.setView(grandchild);
+  parent.setView(child);
+  parent.setView(child);
+
+  ok(child.getView());
+});
+
+test("Cleans up previous child", 1, function() {
+  var callCount = 0;
+  var Test = Backbone.Layout.extend({ template: "" });
+  var parent = new Test();
+  var child = new Test({
+    cleanup: function() {
+      callCount++;
+    }
+  });
+  var grandchild = new Test();
+  var otherChild = new Test();
+
+  child.setView(grandchild);
+  parent.setView(child);
+  parent.setView(otherChild);
+
+  equal(callCount, 1);
+});


### PR DESCRIPTION
Only remove the previously-existing view if it differs from the new
view. This prevents the removal of deeply-nested views.
