### PR TITLE
Ensure LayoutManager works with Browserify.

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -10,8 +10,8 @@
   "trailing": true,
   "unused": true,
   "undef": true,
+  "node": true,
   "globals": {
-    "global": true,
     "define": true
   }
 }

--- a/backbone.layoutmanager.js
+++ b/backbone.layoutmanager.js
@@ -5,7 +5,10 @@
  */
 (function(window, factory) {
   "use strict";
+
   var Backbone = window.Backbone;
+  var _ = window._;
+  var $ = Backbone.$;
 
   // AMD. Register as an anonymous module.  Wrap in function so we have access
   // to root via `this`.
@@ -15,8 +18,18 @@
     });
   }
 
+  // Node. Does not work with strict CommonJS, but only CommonJS-like
+  // enviroments that support module.exports, like Node.
+  else if (typeof exports === "object") {
+    Backbone = require("backbone");
+    _ = require("underscore");
+    $ = require("jquery");
+
+    module.exports = factory.call(window, Backbone, _, $);
+  }
+
   // Browser globals.
-  Backbone.Layout = factory.call(window, Backbone, window._, Backbone.$);
+  Backbone.Layout = factory.call(window, Backbone, _, Backbone.$);
 }(typeof global === "object" ? global : this, function (Backbone, _, $) {
 "use strict";
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "backbone": "~1.1",
     "underscore.deferred": "~0.4",
     "cheerio": "~0.13.1",
+    "jquery": ">=1.6",
     "underscore": ">=1.5"
   },
   "devDependencies": {


### PR DESCRIPTION
- Updated JSHint to allow Node-isms.
- Patched the UMD to require the correct dependencies.
- Ensure that jQuery is installed in Node environments as an optional
  dependency.
