### PR TITLE
Added browserify test & build task, updated UMD definition.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 test/report
+test/tmp
 bower_components

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -5,6 +5,7 @@ module.exports = ->
     "clean"
     "jscs"
     "jshint"
+    "browserify"
     "qunit"
     "nodequnit"
   ]

--- a/backbone.layoutmanager.js
+++ b/backbone.layoutmanager.js
@@ -6,10 +6,6 @@
 (function(window, factory) {
   "use strict";
 
-  var Backbone = window.Backbone;
-  var _ = window._;
-  var $ = Backbone.$;
-
   // AMD. Register as an anonymous module.  Wrap in function so we have access
   // to root via `this`.
   if (typeof define === "function" && define.amd) {
@@ -19,17 +15,21 @@
   }
 
   // Node. Does not work with strict CommonJS, but only CommonJS-like
-  // enviroments that support module.exports, like Node.
+  // environments that support module.exports, like Node.
   else if (typeof exports === "object") {
-    Backbone = require("backbone");
-    _ = require("underscore");
-    $ = require("jquery");
+    var Backbone = require("backbone");
+    var _ = require("underscore");
+    // In a browserify build, since this is the entry point, Backbone.$
+    // is not bound. Ensure that it is.
+    Backbone.$ = Backbone.$ || require("jquery");
 
-    module.exports = factory.call(window, Backbone, _, $);
+    module.exports = factory.call(window, Backbone, _, Backbone.$);
   }
 
   // Browser globals.
-  Backbone.Layout = factory.call(window, Backbone, _, Backbone.$);
+  else {
+    factory.call(window, window.Backbone, window._, window.Backbone.$);
+  }
 }(typeof global === "object" ? global : this, function (Backbone, _, $) {
 "use strict";
 

--- a/build/tasks/browserify.coffee
+++ b/build/tasks/browserify.coffee
@@ -1,0 +1,12 @@
+module.exports = ->
+
+  @config "browserify",
+
+    dist:
+      options:
+        bundleOptions:
+          standalone: 'browserifyLM'
+      src: 'backbone.layoutmanager.js',
+      dest: 'test/tmp/backbone.layoutmanager.browserify.js'
+
+  @loadNpmTasks "grunt-browserify"

--- a/build/tasks/qunit.coffee
+++ b/build/tasks/qunit.coffee
@@ -6,7 +6,7 @@ module.exports = ->
 
       coverage:
         src: ["backbone.layoutmanager.js"]
-        instrumentedFiles: "test/tmp"
+        instrumentedFiles: "test/tmp/coverage"
         htmlReport: "test/report/coverage"
         coberturaReport: "test/report"
         lcovReport: "test/report"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
     "grunt-qunit-istanbul": "~0.3.0",
     "grunt-nodequnit": "~0.2.0",
     "grunt-benchmark": "~0.2.0",
-    "grunt-jscs-checker": "~0.4.1"
+    "grunt-jscs-checker": "~0.4.1",
+    "browserify": "~3.37.0",
+    "grunt-browserify": "~2.0.3"
   },
   "scripts": {
     "test": "grunt"

--- a/test/spec/.jshintrc
+++ b/test/spec/.jshintrc
@@ -1,0 +1,31 @@
+{
+  "browser": true,
+  "boss": true,
+  "immed": false,
+  "eqnull": true,
+  "maxlen": 80,
+  "es3": true,
+  "curly": true,
+  "quotmark": "double",
+  "trailing": true,
+  "unused": true,
+  "undef": true,
+  "node": true,
+  "globals": {
+    "asyncTest"      : true
+    "deepEqual"      : true
+    "equal"          : true
+    "expect"         : true
+    "module"         : true
+    "notDeepEqual"   : true
+    "notEqual"       : true
+    "notStrictEqual" : true
+    "ok"             : true
+    "QUnit"          : true
+    "raises"         : true
+    "start"          : true
+    "stop"           : true
+    "strictEqual"    : true
+    "test"           : true
+  }
+}

--- a/test/spec/expose.js
+++ b/test/spec/expose.js
@@ -19,6 +19,7 @@ asyncTest("AMD support", 1, function() {
   var requirejs = require;
   var useLM = true;
 
+  // Node
   if (!window.define) {
     requirejs = require("requirejs");
     useLM = false;
@@ -68,5 +69,28 @@ test("attached", 2, function() {
   ok(!_.isFunction(this.LayoutManager),
     "LayoutManager shortcut is not a function");
 });
+
+// Browser only - ensure browserified module can be loaded
+if (window.define) {
+  asyncTest("Browserify support", 2, function() {
+    var requirejs = require;
+    // Ensure that the browserify-built LM version works.
+    requirejs(["test/tmp/backbone.layoutmanager.browserify"], function(LayoutManager) {
+      ok(LayoutManager.VERSION, "Version property exists");
+
+      // Create a new layout with a sample template.
+      var layout = new LayoutManager({
+        template: testUtil.templates.main
+      });
+
+      // Render and check.
+      layout.render().promise().then(function() {
+        equal(this.$el.html().trim(), "Left", "Correct render output.");
+        start();
+      });
+    });
+  });
+}
+
 
 })(typeof global !== "undefined" ? global : this);


### PR DESCRIPTION
The UMD definition in #436 was close but had an issue with [L11](https://github.com/tbranyen/backbone.layoutmanager/commit/ca5a3edf0397738058e6d3194461740832ec4b33#diff-ba55fcfab2e1723ff437c1eec10d55e4R11). This line could actually be stricken as the var was never used.

This PR cleans up the UMD definition, moving the browser definition into the `else` block. Additionally, I removed the explicit bind to `window.Backbone.Layout`, as it is already exported on [L834](https://github.com/tbranyen/backbone.layoutmanager/blob/ca5a3edf0397738058e6d3194461740832ec4b33/backbone.layoutmanager.js#L834).

This PR also adds a browserify build task and a basic test to ensure template rendering works with the browserified build.
