### PR TITLE
Updated the conditional AMD define() wrapper

### DIFF
--- a/backbone.layoutmanager.js
+++ b/backbone.layoutmanager.js
@@ -9,7 +9,7 @@
   // AMD. Register as an anonymous module.  Wrap in function so we have access
   // to root via `this`.
   if (typeof define === "function" && define.amd) {
-    return define(["backbone", "underscore", "jquery"], function() {
+    define(["backbone", "underscore", "jquery"], function() {
       return factory.apply(window, arguments);
     });
   }


### PR DESCRIPTION
Removed the `return` statement that was causing issues for AMDclean users: https://github.com/gfranko/amdclean/issues/49. Re: #443
