### PR TITLE
Fix #445, where a removed view could still render asynchronously.

### DIFF
--- a/test/spec/views.js
+++ b/test/spec/views.js
@@ -2616,6 +2616,21 @@ test("Cleans up previous child", 1, function() {
   equal(callCount, 1);
 });
 
+// https://github.com/tbranyen/backbone.layoutmanager/issues/445
+asyncTest("Subviews should not be rendered asynchronously if removed from the parent view synchronously", 1, function() {
+  var Child = Backbone.Layout.extend({
+    className: "child"
+  });
+
+  var layout = new Backbone.Layout();
+  layout.insertView(new Child()).render();
+  layout.getView({className: "child"}).remove();
+  layout.render().then(function(){
+    equal(layout.$(".child").length, 0, "No children");
+    start();
+  });
+});
+
 // No tests below here!
 }
 })();


### PR DESCRIPTION
Refactored canceling a queued RAF render into another method so it could easily be called in `_removeView`.
