### PR TITLE
Use documented jQuery API

### DIFF
--- a/backbone.layoutmanager.js
+++ b/backbone.layoutmanager.js
@@ -1025,7 +1025,7 @@ var defaultOptions = {
   // Override this with a custom HTML method, passed a root element and content
   // (a jQuery collection or a string) to replace the innerHTML with.
   html: function($root, content) {
-    $root.html(content);
+    $root.empty().append(content);
   },
 
   // Used for inserting subViews in a single batch.  This gives a small


### PR DESCRIPTION
Passing a string to the `$.fn.html` method works in the latest version
of the jQuery library, but this signature is neither documented [1] nor
tested [2]. This code does not work with the latest version of the
Cheerio library, and because it is non-standard, it is unlikely to be
implemented in a future version.

Use `$.fn.empty` and `$.fn.append` to implement the desired behavior in
a way that is compatable with Cheerio and unlikely to be removed in a
future release of jQuery.

[1] http://api.jquery.com/html/
[2] https://github.com/jquery/jquery/blob/2380028ec4a6a77401b867a51de26a3cb8e8d311/test/unit/manipulation.js