### PR TITLE
Specify jquery as a peer dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,10 @@
     "backbone": "^1.1.2",
     "underscore.deferred": "^0.4.0",
     "cheerio": "^0.14.0",
-    "jquery": "^2.1.3",
     "underscore": "^1.7.0"
+  },
+  "peerDependencies": {
+    "jquery": "*"
   },
   "devDependencies": {
     "browserify": "^8.1.3",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "grunt-jscs-checker": "^0.4.4",
     "grunt-nodequnit": "^0.2.0",
     "grunt-qunit-istanbul": "^0.4.7",
+    "jquery": "^2.1.3",
     "qunitjs": "^1.17.1",
     "requirejs": "^2.1.16"
   },


### PR DESCRIPTION
This make jquery a "peerDependency" instead of a "dependency".

Suppose you do:

    npm install --save jquery@1.11.2
    npm install --save backbone
    npm install --save backbone.layoutmanager

And then in your source:

    $ = require('jquery');
    backbone = require('backbone');
    backbone.$ = $;
    require('backbone.layoutmanager');

When you try to build your bundle with browserify, you'll end up with a bundle that contains jquery
1.11.2 (because you included it explicitly above) but it will *also* include a ~275K copy of jquery
2.1.3, because backbone.layoutmanager specifically requests a jquery v2.x or higher.

This second copy of jquery will [never be used](https://github.com/tbranyen/backbone.layoutmanager/blob/master/backbone.layoutmanager.js#L24), but that doesn't matter; browserify
will still include it in the bundle (since, of course, browserify has no way to know ahead of
time whether it will be needed or not.)

Making jquery a peer dependency makes it so users of backbone.layoutmanager must explicitly declare
what version of jquery they want in their project's package.json file, and for those of us sad,
tortured souls who must support IE8, we can use 1.11.2 a make a smaller bundle.  :)