### PR TITLE
Update dependency on Cheerio

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "backbone": "^1.1.2",
     "underscore.deferred": "^0.4.0",
-    "cheerio": "^0.14.0",
+    "cheerio": "^0.19.0",
     "underscore": "^1.7.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
@tbranyen We talked about this a while ago. The problem was in two parts: one in our tests ([fixed here](https://github.com/tbranyen/backbone.layoutmanager/pull/468)) and one in Cheerio itself ([fixed here](https://github.com/cheeriojs/cheerio/pull/660)). Sorry for the delay--I've been waiting on a new release of Cheerio.

Commit message:

> Recent releases of the Cheerio library included a regression that
> triggered test failures in this project. The latest release of Cheerio
> addresses that regression.