### PR TITLE
Prevent rendering in `beforeRender`

### DIFF
--- a/backbone.layoutmanager.js
+++ b/backbone.layoutmanager.js
@@ -84,7 +84,20 @@ var LayoutManager = Backbone.View.extend({
 
     // If a beforeRender function is defined, call it.
     if (beforeRender) {
-      beforeRender.call(view, view);
+      var ret = beforeRender.call(view, view);
+
+      if (ret && ret.then) {
+        manager.isAsync = true;
+        ret.then(function() {
+          manager.callback();
+
+          def.resolve();
+        }, def.resolve);
+      }
+
+      if (ret === false) {
+        return def.resolve();
+      }
     }
 
     if (!manager.isAsync) {

--- a/test/spec/views.js
+++ b/test/spec/views.js
@@ -2687,6 +2687,73 @@ asyncTest("Subviews should not be rendered asynchronously if removed from the pa
   });
 });
 
+asyncTest("Renders can be prevented in beforeRender with falsy return value", function() {
+  var TestView = Backbone.Layout.extend({
+    active: false,
+    counter: 0,
+
+    template: function() {
+      return this.counter;
+    },
+
+    beforeRender: function() {
+      this.counter++; 
+      return !this.active;
+    },
+
+    afterRender: function() {
+      this.active = true;
+    }
+  });
+
+  var testView = new TestView();
+
+  testView.render().then(function(){
+    testView.render().then(function() {
+      equal(testView.$el.text(), "1", "Has correct render value");
+      start();
+    });
+  });
+});
+
+asyncTest("Renders can be prevented in beforeRender with a rejected Promise", function() {
+  var TestView = Backbone.Layout.extend({
+    active: false,
+    counter: 0,
+
+    template: function() {
+      return this.counter;
+    },
+
+    beforeRender: function() {
+      this.counter++; 
+      var dfd = new Backbone.$.Deferred();
+
+      if (!this.active) {
+        dfd.resolve();
+      }
+      else {
+        dfd.reject();
+      }
+
+      return dfd.promise();
+    },
+
+    afterRender: function() {
+      this.active = true;
+    }
+  });
+
+  var testView = new TestView();
+
+  testView.render().then(function(){
+    testView.render().then(function() {
+      equal(testView.$el.text(), "1", "Has correct render value");
+      start();
+    });
+  });
+});
+
 // No tests below here!
 }
 })();


### PR DESCRIPTION
This would allow returning false or rejecting a Promise in `beforeRender` to prevent rendering.  This reduces flicker and amount of "empty renders".