### PR TITLE
Update travis

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,1 @@
+service_name: travis-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: node_js
 
 node_js:
   - "0.10"
-  - 0.11
+  - 0.12
+  - iojs
 
 branches:
   only:
@@ -14,5 +15,3 @@ before_script:
 
 matrix:
   fast_finish: true
-  allow_failures:
-    - node_js: 0.11

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,7 @@ branches:
 before_script:
   - npm install -g grunt-cli
 
+after_success: cat test/report/lcov.info | node_modules/.bin/coveralls --verbose
+
 matrix:
   fast_finish: true

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 LayoutManager
 -------------
 
-[![NPM version][npm-image]][npm-url] [![Build status][travis-image]][travis-url]
+[![NPM version][npm-image]][npm-url] [![Build status][travis-image]][travis-url] [![Code coverage][coveralls-image]][coveralls-url]
 
 ## Have a problem? Come chat with us! ##
 
@@ -69,3 +69,5 @@ a headless browser and Node.js environment.
 [travis-image]: https://img.shields.io/travis/tbranyen/backbone.layoutmanager.svg
 [npm-url]: https://npmjs.org/package/backbone.layoutmanager
 [npm-image]: https://img.shields.io/npm/v/backbone.layoutmanager.svg
+[coveralls-url]: https://coveralls.io/r/tbranyen/backbone.layoutmanager
+[coveralls-image]: https://img.shields.io/coveralls/tbranyen/backbone.layoutmanager.svg

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "browserify": "^8.1.3",
     "colors": "^1.0.3",
+    "coveralls": "^2.11.2",
     "grunt": "^0.4.5",
     "grunt-benchmark": "^0.3.0",
     "grunt-browserify": "^3.3.0",


### PR DESCRIPTION
As 0.12 is released, no reason to build on unstable 0.11.

I also added some https://coveralls.io support. If you register there (free for FOSS), just removing the comment in `.travis.yml` should be enough to submit there.

If you use coveralls, I can update #473 to include a coverage badge as well :smile: 