### PR TITLE
Update JSCS

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,11 @@
+root = true
+
 [*]
 insert_final_newline = true
+charset = utf-8
 indent_style = space
 indent_size = 2
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.jscsrc
+++ b/.jscsrc
@@ -9,7 +9,7 @@
   },
 
   "validateLineBreaks": "LF",
-  "validateQuoteMarks": true,
+  "validateQuoteMarks": { "mark": "\"", "escape": true },
 
   "requireCurlyBraces": [
     "if",
@@ -59,10 +59,15 @@
     "==",
     "===",
     "!=",
-    "!=="
+    "!==",
+    ">",
+    ">=",
+    "<",
+    "<="
   ],
 
   "requireSpaceAfterBinaryOperators": [
+    ",",
     "+",
     "-",
     "/",
@@ -71,16 +76,18 @@
     "==",
     "===",
     "!=",
-    "!=="
+    "!==",
+    ">",
+    ">=",
+    "<",
+    "<="
   ],
 
-  "requireRightStickedOperators": [
-    "!"
-  ],
-
-  "requireLeftStickedOperators": [
+  "disallowSpaceBeforeBinaryOperators": [
     ","
   ],
+
+  "requireSpacesInConditionalExpression": true,
 
   "requireKeywordsOnNewLine": [
     "catch",
@@ -91,28 +98,15 @@
     "beforeOpeningCurlyBrace": true
   },
 
+  "disallowSpacesInFunctionExpression": {
+    "beforeOpeningRoundBrace": true
+  },
+
   "requireParenthesesAroundIIFE": true,
   "requireCommaBeforeLineBreak": true,
   "requireCamelCaseOrUpperCaseIdentifiers": true,
   "requireCapitalizedConstructors": true,
   "requireDotNotation": true,
-
-  "disallowLeftStickedOperators": [
-    "?",
-    "+",
-    "-",
-    "/",
-    "*",
-    "=",
-    "==",
-    "===",
-    "!=",
-    "!==",
-    ">",
-    ">=",
-    "<",
-    "<="
-  ],
 
   "disallowSpaceAfterPrefixUnaryOperators": [
     "++",
@@ -121,23 +115,6 @@
     "-",
     "~",
     "!"
-  ],
-
-  "disallowRightStickedOperators": [
-    "?",
-    "+",
-    "/",
-    "*",
-    ":",
-    "=",
-    "==",
-    "===",
-    "!=",
-    "!==",
-    ">",
-    ">=",
-    "<",
-    "<="
   ],
 
   "disallowSpaceBeforePostfixUnaryOperators": [

--- a/backbone.layoutmanager.js
+++ b/backbone.layoutmanager.js
@@ -30,7 +30,7 @@
   else {
     factory.call(window, window.Backbone, window._, window.Backbone.$);
   }
-}(typeof global === "object" ? global : this, function (Backbone, _, $) {
+}(typeof global === "object" ? global : this, function(Backbone, _, $) {
 "use strict";
 
 // Create a reference to the global object. In browsers, it will map to the

--- a/build/tasks/jscs.coffee
+++ b/build/tasks/jscs.coffee
@@ -1,8 +1,5 @@
 module.exports = ->
-  @loadNpmTasks "grunt-jscs-checker"
+  @loadNpmTasks "grunt-jscs"
 
   @config "jscs",
-    options:
-      config: ".jscs.json"
-
     src: "backbone.layoutmanager.js"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "grunt-browserify": "^3.3.0",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-jshint": "^0.11.0",
-    "grunt-jscs-checker": "^0.4.4",
+    "grunt-jscs": "^1.6.0",
     "grunt-nodequnit": "^0.2.0",
     "grunt-qunit-istanbul": "^0.4.7",
     "jquery": "^2.1.3",


### PR DESCRIPTION
When doing `npm install`, I noticed `grunt-jscs-checker` was deprecated.
Upgrading it meant jumping from jscs 1.4.5 to 1.12.0 (latest), with a few changes to the rules.

I _think_ I covered them all.