### PR TITLE
Use `files` in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,11 @@
     "url": "git://github.com/tbranyen/backbone.layoutmanager.git"
   },
   "main": "node/index",
+  "files": [
+    "backbone.layoutmanager.js",
+    "node/index.js",
+    "test/"
+  ],
   "browser": "./backbone.layoutmanager.js",
   "engines": {
     "node": ">=0.8"


### PR DESCRIPTION
Avoids getting a ton of extra files when `npm install`ing your package

Before: http://hastebin.com/veboyiculi.sh
After: http://hastebin.com/vibakudase.sh