### PR TITLE
fix removeView for lodash 3

### DIFF
--- a/backbone.layoutmanager.js
+++ b/backbone.layoutmanager.js
@@ -385,11 +385,21 @@ var LayoutManager = Backbone.View.extend({
   // Use this to remove Views, internally uses `getViews` so you can pass the
   // same argument here as you would to that method.
   removeView: function(fn) {
+    var views;
+
     // Allow an optional selector or function to find the right model and
     // remove nested Views based off the results of the selector or filter.
-    return this.getViews(fn).each(function(nestedView) {
+    views = this.getViews(fn).each(function(nestedView) {
       nestedView.remove();
     });
+
+    // If the chain is evaluated lazily, explicitly execute the chain to remove
+    // the views
+    if (typeof views.commit === "function") {
+      views.commit();
+    }
+
+    return views;
   },
 
   // This takes in a partial name and view instance and assigns them to
@@ -731,7 +741,9 @@ var LayoutManager = Backbone.View.extend({
       if (view.hasRendered || force) {
         LayoutManager._removeView(view, force);
       }
-    });
+
+    // call value() in case this chain is evaluated lazily
+    }).value();
   },
 
   // Remove a single nested View.

--- a/backbone.layoutmanager.js
+++ b/backbone.layoutmanager.js
@@ -393,11 +393,9 @@ var LayoutManager = Backbone.View.extend({
       nestedView.remove();
     });
 
-    // If the chain is evaluated lazily, explicitly execute the chain to remove
-    // the views
-    if (typeof views.commit === "function") {
-      views.commit();
-    }
+    // call value incase the chain is evaluated lazily to ensure the views get
+    // removed
+    views.value();
 
     return views;
   },

--- a/backbone.layoutmanager.js
+++ b/backbone.layoutmanager.js
@@ -864,6 +864,11 @@ var LayoutManager = Backbone.View.extend({
     if (options.useRAF === false) {
       Backbone.View.prototype.useRAF = false;
     }
+
+    // Allow underscore to be swapped out
+    if (options._) {
+      _ = options._;
+    }
   },
 
   // Configure a View to work with the LayoutManager plugin.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "backbone": "^1.1.2",
     "underscore.deferred": "^0.4.0",
     "cheerio": "^0.19.0",
-    "underscore": "^1.7.0"
+    "underscore": "^1.7.0",
+    "lodash": "^3.7.0"
   },
   "peerDependencies": {
     "jquery": "*"

--- a/test/index.html
+++ b/test/index.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="../node_modules/qunitjs/qunit/qunit.css">
   <script src="../node_modules/qunitjs/qunit/qunit.js"></script>
   <script src="../node_modules/jquery/dist/jquery.js"></script>
-  <script src="../node_modules/underscore/underscore.js"></script>
+  <script src="../node_modules/lodash/index.js"></script>
   <script src="../node_modules/backbone/backbone.js"></script>
   <script src="../backbone.layoutmanager.js"></script>
   <script src="../node_modules/requirejs/require.js"></script>

--- a/test/index.html
+++ b/test/index.html
@@ -7,7 +7,12 @@
   <link rel="stylesheet" href="../node_modules/qunitjs/qunit/qunit.css">
   <script src="../node_modules/qunitjs/qunit/qunit.js"></script>
   <script src="../node_modules/jquery/dist/jquery.js"></script>
+  <script src="../node_modules/underscore/underscore.js"></script>
   <script src="../node_modules/lodash/index.js"></script>
+  <script>
+    var lodash = _.noConflict();
+    var underscore = _;
+  </script>
   <script src="../node_modules/backbone/backbone.js"></script>
   <script src="../backbone.layoutmanager.js"></script>
   <script src="../node_modules/requirejs/require.js"></script>

--- a/test/spec/expose.js
+++ b/test/spec/expose.js
@@ -29,7 +29,7 @@ asyncTest("AMD support", 1, function() {
     baseUrl: "../",
 
     paths: {
-      underscore: "node_modules/lodash/index",
+      underscore: "node_modules/underscore/underscore",
       jquery: "node_modules/jquery/dist/jquery",
       backbone: "node_modules/backbone/backbone"
     }

--- a/test/spec/expose.js
+++ b/test/spec/expose.js
@@ -29,7 +29,7 @@ asyncTest("AMD support", 1, function() {
     baseUrl: "../",
 
     paths: {
-      underscore: "node_modules/underscore/underscore",
+      underscore: "node_modules/lodash/index",
       jquery: "node_modules/jquery/dist/jquery",
       backbone: "node_modules/backbone/backbone"
     }

--- a/test/spec/views.js
+++ b/test/spec/views.js
@@ -2762,6 +2762,7 @@ test("Calls commit when removing views", function() {
   
   var origCommit = _.commit;
   var commitCalled = false;
+  
   _.prototype.commit = function() {
     if (typeof origCommit === "function") {
       origCommit.call(_);

--- a/test/spec/views.js
+++ b/test/spec/views.js
@@ -2754,6 +2754,28 @@ asyncTest("Renders can be prevented in beforeRender with a rejected Promise", fu
   });
 });
 
+test("Calls commit when removing views", function() {
+  var child = new Backbone.Layout();
+  var parent = new Backbone.Layout();
+
+  parent.setView("child", child);
+  
+  var origCommit = _.commit;
+  var commitCalled = false;
+  _.prototype.commit = function() {
+    if (typeof origCommit === "function") {
+      origCommit.call(_);
+    }
+    commitCalled = true;
+  };
+
+  parent.removeView("child");
+  
+  _.prototype.commit = origCommit;
+
+  ok(commitCalled, "commit was called");
+});
+
 // No tests below here!
 }
 })();

--- a/test/spec/views.js
+++ b/test/spec/views.js
@@ -2754,31 +2754,6 @@ asyncTest("Renders can be prevented in beforeRender with a rejected Promise", fu
   });
 });
 
-test("Calls commit when removing views", function() {
-  var child = new Backbone.Layout();
-  var parent = new Backbone.Layout();
-
-  parent.setView("child", child);
-  
-  var origCommit = _.prototype.commit;
-  var commitCalled = false;
-  
-  _.prototype.commit = function() {
-    if (typeof origCommit === "function") {
-      origCommit.call(this);
-    }
-    commitCalled = true;
-  };
-
-  parent.removeView("child");
-  
-  _.prototype.commit = origCommit;
-  
-  ok(parent.getView("child") === undefined, "child view was removed");
-
-  ok(commitCalled, "commit was called");
-});
-
 // No tests below here!
 }
 })();

--- a/test/spec/views.js
+++ b/test/spec/views.js
@@ -1,6 +1,6 @@
 (function() {
 "use strict";
-/*global testUtil */
+/*global testUtil, underscore, lodash */
 
 //
 // Test suite definitions.
@@ -18,10 +18,16 @@ function createOptions(options) {
   };
 }
 
-QUnit.module("views (RAF: false)", createOptions({useRAF: false}));
+QUnit.module("views (RAF: false, underscore)", createOptions({useRAF: false, _: underscore}));
 defineTests();
 
-QUnit.module("views (RAF: true)", createOptions({useRAF: true}));
+QUnit.module("views (RAF: true, underscore)", createOptions({useRAF: true, _: underscore}));
+defineTests();
+
+QUnit.module("views (RAF: false, lodash)", createOptions({useRAF: false, _: lodash}));
+defineTests();
+
+QUnit.module("views (RAF: true, lodash)", createOptions({useRAF: true, _: lodash}));
 defineTests();
 
 //
@@ -34,6 +40,9 @@ function setup(testModule, globalOptions) {
   // default `fetchTemplate` method to be restored in the teardown of this test
   // module.
   testModule.origFetch = Backbone.Layout.prototype.fetchTemplate;
+
+  // keep a reference to the current utility library for mocking
+  testModule._ = globalOptions._ || _;
 
   Backbone.Layout.configure(_.extend({
     fetchTemplate: function(name) {
@@ -2638,6 +2647,54 @@ asyncTest("template method context", 1, function() {
   layout.render().then(start);
 });
 
+test("removeView calls .value() in case the getViews() wrapper is executed lazily", function() {
+  var child = new Backbone.Layout();
+  var parent = new Backbone.Layout();
+
+  parent.setView("child", child);
+
+  var _ = this._;
+  var origValue = _.prototype.value;
+  var valueCalled = false;
+
+  _.prototype.value = function() {
+      origValue.call(this);
+      valueCalled = true;
+  };
+
+  parent.removeView("child");
+
+  _.prototype.value = origValue;
+
+  ok(parent.getView("child") === undefined, "child view was removed");
+
+  ok(valueCalled, ".value() was called");
+});
+
+test("_removeViews calls .value() in case the getViews() wrapper is executed lazily", function() {
+  var child = new Backbone.Layout();
+  var parent = new Backbone.Layout();
+
+  parent.setView("child", child);
+
+  var _ = this._;
+  var origValue = _.prototype.value;
+  var valueCalled = false;
+
+  _.prototype.value = function() {
+      origValue.call(this);
+      valueCalled = true;
+  };
+
+  parent._removeViews(true);
+
+  _.prototype.value = origValue;
+
+  ok(parent.getView("child") === undefined, "child view was removed");
+
+  ok(valueCalled, ".value() was called");
+});
+
 QUnit.module("setView");
 
 test("Does not remove child's children", 1, function() {
@@ -2752,52 +2809,6 @@ asyncTest("Renders can be prevented in beforeRender with a rejected Promise", fu
       start();
     });
   });
-});
-
-test("removeView calls .value() in case the getViews() wrapper is executed lazily", function() {
-  var child = new Backbone.Layout();
-  var parent = new Backbone.Layout();
-
-  parent.setView("child", child);
-
-  var origValue = _.prototype.value;
-  var valueCalled = false;
-
-  _.prototype.value = function() {
-      origValue.call(this);
-      valueCalled = true;
-  };
-
-  parent.removeView("child");
-
-  _.prototype.value = origValue;
-
-  ok(parent.getView("child") === undefined, "child view was removed");
-
-  ok(valueCalled, ".value() was called");
-});
-
-test("_removeViews calls .value() in case the getViews() wrapper is executed lazily", function() {
-  var child = new Backbone.Layout();
-  var parent = new Backbone.Layout();
-
-  parent.setView("child", child);
-
-  var origValue = _.prototype.value;
-  var valueCalled = false;
-
-  _.prototype.value = function() {
-      origValue.call(this);
-      valueCalled = true;
-  };
-
-  parent._removeViews(true);
-
-  _.prototype.value = origValue;
-
-  ok(parent.getView("child") === undefined, "child view was removed");
-
-  ok(valueCalled, ".value() was called");
 });
 
 // No tests below here!

--- a/test/spec/views.js
+++ b/test/spec/views.js
@@ -2754,6 +2754,52 @@ asyncTest("Renders can be prevented in beforeRender with a rejected Promise", fu
   });
 });
 
+test("removeView calls .value() in case the getViews() wrapper is executed lazily", function() {
+  var child = new Backbone.Layout();
+  var parent = new Backbone.Layout();
+
+  parent.setView("child", child);
+
+  var origValue = _.prototype.value;
+  var valueCalled = false;
+
+  _.prototype.value = function() {
+      origValue.call(this);
+      valueCalled = true;
+  };
+
+  parent.removeView("child");
+
+  _.prototype.value = origValue;
+
+  ok(parent.getView("child") === undefined, "child view was removed");
+
+  ok(valueCalled, ".value() was called");
+});
+
+test("_removeViews calls .value() in case the getViews() wrapper is executed lazily", function() {
+  var child = new Backbone.Layout();
+  var parent = new Backbone.Layout();
+
+  parent.setView("child", child);
+
+  var origValue = _.prototype.value;
+  var valueCalled = false;
+
+  _.prototype.value = function() {
+      origValue.call(this);
+      valueCalled = true;
+  };
+
+  parent._removeViews(true);
+
+  _.prototype.value = origValue;
+
+  ok(parent.getView("child") === undefined, "child view was removed");
+
+  ok(valueCalled, ".value() was called");
+});
+
 // No tests below here!
 }
 })();

--- a/test/spec/views.js
+++ b/test/spec/views.js
@@ -2101,7 +2101,7 @@ asyncTest("`el: false` with rerendering inserted child views doesn't replicate v
     var checkHTML = _.after(2, doCheck);
     view.getViews(".list").forEach(function(aView){
       aView.on("afterRender", checkHTML);
-    });
+    }).value();
     function doCheck(){
       equal(view.$el.html(), expected.join(""), "the same HTML");
       start();
@@ -2331,7 +2331,7 @@ asyncTest("passing filter function to `getViews`", 2, function() {
   view.render().then(function(){
     view.getViews(function(view) {
       ok(view instanceof Backbone.Layout, "Is a Backbone View");
-    });
+    }).value();
     start();
   });
 });
@@ -2760,12 +2760,12 @@ test("Calls commit when removing views", function() {
 
   parent.setView("child", child);
   
-  var origCommit = _.commit;
+  var origCommit = _.prototype.commit;
   var commitCalled = false;
   
   _.prototype.commit = function() {
     if (typeof origCommit === "function") {
-      origCommit.call(_);
+      origCommit.call(this);
     }
     commitCalled = true;
   };
@@ -2773,6 +2773,8 @@ test("Calls commit when removing views", function() {
   parent.removeView("child");
   
   _.prototype.commit = origCommit;
+  
+  ok(parent.getView("child") === undefined, "child view was removed");
 
   ok(commitCalled, "commit was called");
 });

--- a/test/util/util.js
+++ b/test/util/util.js
@@ -35,4 +35,6 @@ var testUtil = {
 // module.
 if (testUtil.inNodeJs()) {
   exports.testUtil = testUtil;
+  exports.lodash = require("lodash");
+  exports.underscore = require("underscore");
 }


### PR DESCRIPTION
From what I could find, backbone.layoutmanager doesn't officially support lodash (the "modern" build anyway), but I put together this PR for your consideration. The problem I ran into is that the lazy evaluation introduced in lodash 3 prevents `.removeView` from executing. [Here's a very simple jsFiddle](http://jsfiddle.net/seanparmelee/kmm8ohbm/) to demonstrate.