### PR TITLE
Use files in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
   },
   "main": "node/index",
   "browser": "./backbone.layoutmanager.js",
+  "files": [
+    "node/index.js",
+    "backbone.layoutmanager.js"
+  ],
   "engines": {
     "node": ">=0.8"
   },


### PR DESCRIPTION
Reduces the number of files consumer gets when `npm install`ing.

Before: http://hastebin.com/qajajirure.sh
After: http://hastebin.com/vazatiwito.sh