### PR TITLE
Support for Backbone 1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,18 @@ http://layoutmanager.org/From-0.8-to-0.9
 [Full Release
 Log](https://github.com/tbranyen/backbone.layoutmanager/blob/master/CHANGELOG.md)
 
+#### Cheerio Users
+
+Backbone 1.2.* and above are no longer compatible with cheerio out of the box, so be sure to add the following [custom hook](https://github.com/jashkenas/backbone/wiki/Using-Backbone-without-jQuery):
+
+```js
+Backbone.View.prototype._createElement = function(tagName) {
+  var tag = "<" + tagName + ">" + "</" + tagName + ">";
+  return $.load(tag).root()[0].children[0];
+};
+```
+
+
 #### Contributing ####
 
 Please read and follow the [contribution

--- a/README.md
+++ b/README.md
@@ -36,18 +36,6 @@ http://layoutmanager.org/From-0.8-to-0.9
 [Full Release
 Log](https://github.com/tbranyen/backbone.layoutmanager/blob/master/CHANGELOG.md)
 
-#### Cheerio Users
-
-Backbone 1.2.* and above are no longer compatible with cheerio out of the box, so be sure to add the following [custom hook](https://github.com/jashkenas/backbone/wiki/Using-Backbone-without-jQuery):
-
-```js
-Backbone.View.prototype._createElement = function(tagName) {
-  var tag = "<" + tagName + ">" + "</" + tagName + ">";
-  return $.load(tag).root()[0].children[0];
-};
-```
-
-
 #### Contributing ####
 
 Please read and follow the [contribution

--- a/bower.json
+++ b/bower.json
@@ -5,6 +5,6 @@
   "dependencies": {
     "jquery": ">=1.6",
     "underscore": ">=1.5",
-    "backbone": "~1.1"
+    "backbone": "~1.2"
   }
 }

--- a/node/index.js
+++ b/node/index.js
@@ -9,6 +9,12 @@ var _ = require("underscore");
 // also much faster than jsdom.
 var $ = require("cheerio");
 
+// Add cheerio hooks
+Backbone.View.prototype._createElement = function(tagName) {
+  var tag = "<" + tagName + ">" + "</" + tagName + ">";
+  return $.load(tag).root()[0].children[0];
+};
+
 // This is to avoid unwanted errors thrown when using
 // `Backbone.View#setElement`.
 $.prototype.unbind = $.prototype.off = function() { return this; };

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "node": ">=0.8"
   },
   "dependencies": {
-    "backbone": "1.1.2",
+    "backbone": "1.2.3",
     "underscore.deferred": "^0.4.0",
     "cheerio": "^0.19.0",
     "underscore": "^1.8.3",
@@ -51,7 +51,7 @@
   "jam": {
     "dependencies": {
       "underscore": ">=1.5",
-      "backbone": "~1.1",
+      "backbone": "~1.2",
       "jquery": ">=1.6"
     },
     "include": [


### PR DESCRIPTION
-Updated readme with cheerio hook info
-Updated to Backbone 1.2.0 dependency
-Fixed Node unit tests by providing a special _createElement View hook for cheerio

Issue Reference: https://github.com/tbranyen/backbone.layoutmanager/issues/481

@tbranyen Let me know if there's anything else!